### PR TITLE
Add OpenAPI v2 proposal with clarified endpoint naming

### DIFF
--- a/openapi_v2.yaml
+++ b/openapi_v2.yaml
@@ -1,0 +1,156 @@
+openapi: 3.1.0
+info:
+  title: Nutrition Logger API
+  version: "2.0.0"
+  description: >-
+    API for recording and retrieving detailed nutrition entries stored in
+    a Notion database. All endpoints require an `x-api-key` header.
+servers:
+  - url: https://notionuploader-groa.onrender.com
+paths:
+  /v2/nutrition-entries:
+    post:
+      summary: Create nutrition entry
+      description: >-
+        Record a new food item and its macronutrient breakdown in the Notion
+        database.
+      operationId: createNutritionEntry
+      security:
+        - ApiKeyAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/NutritionEntry"
+      responses:
+        "201":
+          description: Entry successfully created.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: success
+  /v2/nutrition-entries/daily/{date}:
+    get:
+      summary: List nutrition entries for a specific day
+      description: >-
+        Retrieve every nutrition entry recorded on a specific calendar day.
+      operationId: listDailyNutritionEntries
+      security:
+        - ApiKeyAuth: []
+      parameters:
+        - name: date
+          in: path
+          required: true
+          description: Date to fetch in YYYY-MM-DD format.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Array of nutrition entries for the requested day.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/NutritionEntry"
+  /v2/nutrition-entries/period:
+    get:
+      summary: List nutrition entries within a date range
+      description: >-
+        Retrieve all nutrition entries between two dates, inclusive.
+      operationId: listNutritionEntriesByPeriod
+      security:
+        - ApiKeyAuth: []
+      parameters:
+        - name: start_date
+          in: query
+          required: true
+          description: Start date (inclusive) in YYYY-MM-DD format.
+          schema:
+            type: string
+        - name: end_date
+          in: query
+          required: true
+          description: End date (inclusive) in YYYY-MM-DD format.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Array of nutrition entries within the specified period.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/NutritionEntry"
+  /v2/api-schema:
+    get:
+      summary: Retrieve API schema
+      description: Return the OpenAPI specification for this API version.
+      operationId: getApiSchema
+      security:
+        - ApiKeyAuth: []
+      responses:
+        "200":
+          description: OpenAPI schema document.
+          content:
+            application/json:
+              schema:
+                type: object
+components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: x-api-key
+  schemas:
+    NutritionEntry:
+      type: object
+      required:
+        - food_item
+        - date
+        - calories
+        - protein_g
+        - carbs_g
+        - fat_g
+        - meal_type
+        - notes
+      properties:
+        food_item:
+          type: string
+          description: Name of the food item consumed.
+        date:
+          type: string
+          description: Date of consumption in YYYY-MM-DD format.
+        calories:
+          type: integer
+          description: Total calories for the food item.
+        protein_g:
+          type: number
+          description: Protein content in grams.
+        carbs_g:
+          type: number
+          description: Carbohydrate content in grams.
+        fat_g:
+          type: number
+          description: Fat content in grams.
+        meal_type:
+          type: string
+          description: Type of meal when the food was eaten.
+          enum:
+            - Breakfast
+            - Lunch
+            - Dinner
+            - Snack
+            - Pre-workout
+            - Post-workout
+        notes:
+          type: string
+          description: Additional notes or details about the entry.
+security:
+  - ApiKeyAuth: []

--- a/src/main.py
+++ b/src/main.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI, HTTPException, Header, Depends, Query
+from fastapi import FastAPI, HTTPException, Header, Depends, Query, Path
 from fastapi.openapi.utils import get_openapi
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
@@ -17,6 +17,7 @@ def verify_api_key(x_api_key: str = Header(...)):
     if x_api_key != API_KEY:
         raise HTTPException(status_code=401, detail="Unauthorized")
 
+
 app = FastAPI(dependencies=[Depends(verify_api_key)])
 
 
@@ -25,7 +26,7 @@ def custom_openapi():
         return app.openapi_schema
     openapi_schema = get_openapi(
         title="Nutrition Logger",
-        version="1.0.0",
+        version="2.0.0",
         description="Logs food and macro data to Vit's Notion table",
         routes=app.routes,
     )
@@ -49,7 +50,7 @@ app.openapi = custom_openapi
 
 class NutritionEntry(BaseModel):
     food_item: str
-    date: str  # You could refine this to date format later
+    date: str  # Consider refining this to a date type later
     calories: int
     protein_g: float
     carbs_g: float
@@ -60,16 +61,15 @@ class NutritionEntry(BaseModel):
     notes: str = Field(..., min_length=1)
 
 
-@app.post("/")
-async def log_nutrition(entry: NutritionEntry):
-    notion_url = "https://api.notion.com/v1/pages"
-    headers = {
-        "Authorization": f"Bearer {NOTION_SECRET}",
-        "Content-Type": "application/json",
-        "Notion-Version": "2022-06-28"
-    }
+NOTION_HEADERS = {
+    "Authorization": f"Bearer {NOTION_SECRET}",
+    "Content-Type": "application/json",
+    "Notion-Version": "2022-06-28",
+}
 
-    # This payload assumes your Notion table uses property names exactly as shown
+
+async def _submit_to_notion(entry: NutritionEntry) -> dict:
+    """Create a page in the configured Notion database for the entry."""
     payload = {
         "parent": {"database_id": NOTION_DATABASE_ID},
         "properties": {
@@ -80,104 +80,122 @@ async def log_nutrition(entry: NutritionEntry):
             "Carbs (g)": {"number": entry.carbs_g},
             "Fat (g)": {"number": entry.fat_g},
             "Meal Type": {"select": {"name": entry.meal_type}},
-            "Notes": {"rich_text": [{"text": {"content": entry.notes}}]}
-        }
+            "Notes": {"rich_text": [{"text": {"content": entry.notes}}]},
+        },
     }
-
     async with httpx.AsyncClient() as client:
-        response = await client.post(notion_url, json=payload, headers=headers)
-
+        response = await client.post(
+            "https://api.notion.com/v1/pages", json=payload, headers=NOTION_HEADERS
+        )
     if response.status_code != 200:
         raise HTTPException(status_code=response.status_code, detail=response.text)
-
     return {"status": "success"}
 
 
-@app.get("/foods", response_model=list[NutritionEntry])
-async def get_foods_by_date(date: str = Query(..., description="The date for which to retrieve food entries (YYYY-MM-DD)")):
+def _parse_page(page: dict) -> NutritionEntry | None:
+    props = page["properties"]
+    try:
+        return NutritionEntry(
+            food_item=props["Food Item"]["title"][0]["text"]["content"]
+            if props["Food Item"]["title"]
+            else "",
+            date=props["Date"]["date"]["start"] if props["Date"]["date"] else "",
+            calories=props["Calories"]["number"],
+            protein_g=props["Protein (g)"]["number"],
+            carbs_g=props["Carbs (g)"]["number"],
+            fat_g=props["Fat (g)"]["number"],
+            meal_type=
+            props["Meal Type"]["select"]["name"] if props["Meal Type"]["select"] else "",
+            notes=
+            props["Notes"]["rich_text"][0]["text"]["content"]
+            if props["Notes"]["rich_text"]
+            else "",
+        )
+    except Exception:
+        return None
+
+
+async def _query_entries(filter_payload: dict) -> list[NutritionEntry]:
     notion_url = f"https://api.notion.com/v1/databases/{NOTION_DATABASE_ID}/query"
-    headers = {
-        "Authorization": f"Bearer {NOTION_SECRET}",
-        "Content-Type": "application/json",
-        "Notion-Version": "2022-06-28"
-    }
-    # Notion filter for exact date match
-    payload = {
-        "filter": {
-            "property": "Date",
-            "date": {"equals": date}
-        }
-    }
     async with httpx.AsyncClient() as client:
-        response = await client.post(notion_url, json=payload, headers=headers)
+        response = await client.post(
+            notion_url, json={"filter": filter_payload}, headers=NOTION_HEADERS
+        )
     if response.status_code != 200:
         raise HTTPException(status_code=response.status_code, detail=response.text)
     results = response.json().get("results", [])
     entries = []
     for page in results:
-        props = page["properties"]
-        try:
-            entry = NutritionEntry(
-                food_item=props["Food Item"]["title"][0]["text"]["content"] if props["Food Item"]["title"] else "",
-                date=props["Date"]["date"]["start"] if props["Date"]["date"] else "",
-                calories=props["Calories"]["number"],
-                protein_g=props["Protein (g)"]["number"],
-                carbs_g=props["Carbs (g)"]["number"],
-                fat_g=props["Fat (g)"]["number"],
-                meal_type=props["Meal Type"]["select"]["name"] if props["Meal Type"]["select"] else "",
-                notes=props["Notes"]["rich_text"][0]["text"]["content"] if props["Notes"]["rich_text"] else ""
-            )
+        entry = _parse_page(page)
+        if entry:
             entries.append(entry)
-        except Exception as e:
-            continue  # skip malformed entries
     return entries
 
 
-@app.get("/foods-range", response_model=list[NutritionEntry])
-async def get_foods_by_date_range(
-    start_date: str = Query(..., description="The start date (YYYY-MM-DD, inclusive)"),
-    end_date: str = Query(..., description="The end date (YYYY-MM-DD, inclusive)")
-):
-    notion_url = f"https://api.notion.com/v1/databases/{NOTION_DATABASE_ID}/query"
-    headers = {
-        "Authorization": f"Bearer {NOTION_SECRET}",
-        "Content-Type": "application/json",
-        "Notion-Version": "2022-06-28",
-    }
-    payload = {
-        "filter": {
+async def _entries_on_date(date: str) -> list[NutritionEntry]:
+    return await _query_entries({"property": "Date", "date": {"equals": date}})
+
+
+async def _entries_in_range(start_date: str, end_date: str) -> list[NutritionEntry]:
+    return await _query_entries(
+        {
             "and": [
                 {"property": "Date", "date": {"on_or_after": start_date}},
                 {"property": "Date", "date": {"on_or_before": end_date}},
             ]
         }
-    }
-    async with httpx.AsyncClient() as client:
-        response = await client.post(notion_url, json=payload, headers=headers)
-    if response.status_code != 200:
-        raise HTTPException(status_code=response.status_code, detail=response.text)
-    results = response.json().get("results", [])
-    entries = []
-    for page in results:
-        props = page["properties"]
-        try:
-            entry = NutritionEntry(
-                food_item=props["Food Item"]["title"][0]["text"]["content"] if props["Food Item"]["title"] else "",
-                date=props["Date"]["date"]["start"] if props["Date"]["date"] else "",
-                calories=props["Calories"]["number"],
-                protein_g=props["Protein (g)"]["number"],
-                carbs_g=props["Carbs (g)"]["number"],
-                fat_g=props["Fat (g)"]["number"],
-                meal_type=props["Meal Type"]["select"]["name"] if props["Meal Type"]["select"] else "",
-                notes=props["Notes"]["rich_text"][0]["text"]["content"] if props["Notes"]["rich_text"] else "",
-            )
-            entries.append(entry)
-        except Exception:
-            continue  # skip malformed entries
-    return entries
+    )
+
+
+@app.post("/", status_code=200)
+async def log_nutrition(entry: NutritionEntry):
+    return await _submit_to_notion(entry)
+
+
+@app.post("/v2/nutrition-entries", status_code=201)
+async def create_nutrition_entry(entry: NutritionEntry):
+    return await _submit_to_notion(entry)
+
+
+@app.get("/foods", response_model=list[NutritionEntry])
+async def get_foods_by_date(
+    date: str = Query(
+        ..., description="The date for which to retrieve food entries (YYYY-MM-DD)"
+    )
+):
+    return await _entries_on_date(date)
+
+
+@app.get("/v2/nutrition-entries/daily/{date}", response_model=list[NutritionEntry])
+async def list_daily_nutrition_entries(
+    date: str = Path(..., description="Date to fetch in YYYY-MM-DD format.")
+):
+    return await _entries_on_date(date)
+
+
+@app.get("/foods-range", response_model=list[NutritionEntry])
+async def get_foods_by_date_range(
+    start_date: str = Query(..., description="The start date (YYYY-MM-DD, inclusive)"),
+    end_date: str = Query(..., description="The end date (YYYY-MM-DD, inclusive)"),
+):
+    return await _entries_in_range(start_date, end_date)
+
+
+@app.get("/v2/nutrition-entries/period", response_model=list[NutritionEntry])
+async def list_nutrition_entries_by_period(
+    start_date: str = Query(
+        ..., description="Start date (inclusive) in YYYY-MM-DD format."
+    ),
+    end_date: str = Query(
+        ..., description="End date (inclusive) in YYYY-MM-DD format."
+    ),
+):
+    return await _entries_in_range(start_date, end_date)
 
 
 @app.get("/openapi", include_in_schema=False)
-async def get_openapi_endpoint():
-    """Return the OpenAPI schema for this application."""
+@app.get("/v2/api-schema")
+async def get_api_schema():
+    """Return the OpenAPI schema for this API version."""
     return JSONResponse(app.openapi())
+


### PR DESCRIPTION
## Summary
- draft OpenAPI v2 spec with explicit, versioned paths and richer descriptions
- implement `/v2` FastAPI routes for logging and querying nutrition entries
- restore legacy v1 endpoints and refactor shared Notion logic for DRY compliance

## Testing
- `python -m py_compile src/main.py`


------
https://chatgpt.com/codex/tasks/task_e_689602eba1d083308b28d9ef3ec4e06a