### PR TITLE
Define response schema and validate OpenAPI

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -26,11 +26,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": {
-                    "type": "string"
-                  },
-                  "type": "object",
-                  "title": "Response Create Nutrition Entry V2 Nutrition Entries Post"
+                  "$ref": "#/components/schemas/StatusResponse"
                 }
               }
             }
@@ -258,6 +254,20 @@
           "notes"
         ],
         "title": "NutritionEntry"
+      },
+      "StatusResponse": {
+        "properties": {
+          "status": {
+            "type": "string",
+            "title": "Status"
+          }
+        },
+        "type": "object",
+        "required": [
+          "status"
+        ],
+        "title": "StatusResponse",
+        "description": "Simple response model indicating operation status."
       },
       "ValidationError": {
         "properties": {

--- a/openapi_v2.yaml
+++ b/openapi_v2.yaml
@@ -30,6 +30,8 @@ paths:
             application/json:
               schema:
                 type: object
+                required:
+                  - status
                 properties:
                   status:
                     type: string

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ httpx==0.27.0
 pytest==8.2.0
 pytest-asyncio==0.23.5
 respx==0.20.1
+openapi-spec-validator==0.7.2

--- a/src/models.py
+++ b/src/models.py
@@ -14,3 +14,9 @@ class NutritionEntry(BaseModel):
         "Breakfast", "Lunch", "Dinner", "Snack", "Pre-workout", "Post-workout"
     ]
     notes: str = Field(..., min_length=1)
+
+
+class StatusResponse(BaseModel):
+    """Simple response model indicating operation status."""
+
+    status: str

--- a/src/notion.py
+++ b/src/notion.py
@@ -6,9 +6,9 @@ import httpx
 from fastapi import HTTPException
 
 from .config import NOTION_DATABASE_ID, NOTION_HEADERS
-from .models import NutritionEntry
+from .models import NutritionEntry, StatusResponse
 
-async def submit_to_notion(entry: NutritionEntry) -> Dict[str, str]:
+async def submit_to_notion(entry: NutritionEntry) -> StatusResponse:
     """Create a page in the configured Notion database for the entry."""
     payload: Dict[str, Any] = {
         "parent": {"database_id": NOTION_DATABASE_ID},
@@ -29,7 +29,7 @@ async def submit_to_notion(entry: NutritionEntry) -> Dict[str, str]:
         )
     if response.status_code != 200:
         raise HTTPException(status_code=response.status_code, detail=response.text)
-    return {"status": "success"}
+    return StatusResponse(status="success")
 
 def parse_page(page: Dict[str, Any]) -> Optional[NutritionEntry]:
     props: Dict[str, Any] = page["properties"]

--- a/src/routes.py
+++ b/src/routes.py
@@ -5,13 +5,13 @@ from typing import Any, Dict, List
 from fastapi import APIRouter, Path, Query, Request
 from fastapi.responses import JSONResponse
 
-from .models import NutritionEntry
+from .models import NutritionEntry, StatusResponse
 from .notion import entries_in_range, entries_on_date, submit_to_notion
 
 router: APIRouter = APIRouter(prefix="/v2")
 
-@router.post("/nutrition-entries", status_code=201)
-async def create_nutrition_entry(entry: NutritionEntry) -> Dict[str, str]:
+@router.post("/nutrition-entries", status_code=201, response_model=StatusResponse)
+async def create_nutrition_entry(entry: NutritionEntry) -> StatusResponse:
     return await submit_to_notion(entry)
 
 @router.get("/nutrition-entries/daily/{date}", response_model=List[NutritionEntry])

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -8,6 +8,7 @@ import json
 import pytest
 import respx
 from fastapi import FastAPI
+from openapi_spec_validator import validate
 
 # Set environment variables before importing the app
 os.environ["API_KEY"] = "test-key"
@@ -168,6 +169,7 @@ async def test_openapi_schema() -> None:
         )
     assert response.status_code == 200
     schema: Dict[str, Any] = response.json()
+    validate(schema)
     assert (
         schema["components"]["securitySchemes"]["ApiKeyAuth"]["name"]
         == "x-api-key"


### PR DESCRIPTION
## Summary
- add explicit `StatusResponse` model and use it for POST /v2/nutrition-entries
- require `status` field in 201 responses for nutrition entries in OpenAPI spec
- validate generated OpenAPI schema during tests via `openapi-spec-validator`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689631dde5148330807960a344e59f0f