### PR TITLE
Exclude missing values from moving average computation

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -14,6 +14,13 @@ from openapi_spec_validator import validate
 os.environ["API_KEY"] = "test-key"
 os.environ["LLM_Update"] = "notion-secret"
 os.environ["NOTION_DATABASE_ID"] = "db123"
+os.environ["WBSAPI_URL"] = "https://wbs.example.com"
+os.environ["UPSTASH_REDIS_REST_URL"] = "https://redis.example.com"
+os.environ["UPSTASH_REDIS_REST_TOKEN"] = "token"
+os.environ["WITHINGS_CLIENT_ID"] = "client-id"
+os.environ["WITHINGS_CLIENT_SECRET"] = "client-secret"
+os.environ["CLIENT_ID"] = "oauth-client-id"
+os.environ["CUSTOMER_SECRET"] = "oauth-secret"
 
 # Ensure the repository root is on the Python path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))


### PR DESCRIPTION
## Summary
- Ignore `None` values when computing 7-day moving averages so gaps don't dilute results
- Add tests covering partial windows and missing values for metrics
- Set required environment variables in tests to allow configuration loading

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68986ad43ee88330b017afd328bdb725