### PR TITLE
Implement Strava webhook handling and workout logging

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -21,6 +21,11 @@ def get_env_var(name: str) -> str:
 API_KEY: str = get_env_var("API_KEY")
 NOTION_SECRET: str = get_env_var("LLM_Update")
 NOTION_DATABASE_ID: str = get_env_var("NOTION_DATABASE_ID")
+NOTION_WORKOUT_DATABASE_ID: str = get_env_var("NOTION_WORKOUT_DATABASE_ID")
+NOTION_ATHLETE_PROFILE_DATABASE_ID: str = get_env_var(
+    "NOTION_ATHLETE_PROFILE_DATABASE_ID"
+)
+STRAVA_VERIFY_TOKEN: str = get_env_var("STRAVA_VERIFY_TOKEN")
 
 NOTION_HEADERS: Final[Dict[str, str]] = {
     "Authorization": f"Bearer {NOTION_SECRET}",

--- a/src/main.py
+++ b/src/main.py
@@ -4,12 +4,16 @@ from fastapi import Depends, FastAPI
 
 from .routes import router
 from .security import verify_api_key
+from .strava_webhook import webhook_router
 
 app: FastAPI = FastAPI(
     title="Nutrition Logger",
     version="2.0.0",
     description="Logs food and macro data to Vit's Notion table",
-    dependencies=[Depends(verify_api_key)],
 )
 
-app.include_router(router)
+# API endpoints secured by API key
+app.include_router(router, dependencies=[Depends(verify_api_key)])
+
+# Strava webhook endpoints (no API key security)
+app.include_router(webhook_router)

--- a/src/models.py
+++ b/src/models.py
@@ -121,6 +121,38 @@ class Workout(BaseModel):
         )
 
 
+class StravaEvent(BaseModel):
+    """Payload sent by Strava webhook."""
+
+    aspect_type: str
+    event_time: int
+    object_id: int
+    object_type: str
+    owner_id: int
+    subscription_id: int
+    updates: Dict[str, Any] | None = None
+
+
+class WorkoutLog(BaseModel):
+    """Representation of a workout stored in Notion for LLM consumption."""
+
+    name: str
+    date: str
+    duration_s: float
+    distance_m: float
+    elevation_m: float
+    type: str
+    average_cadence: Optional[float] = None
+    average_watts: Optional[float] = None
+    weighted_average_watts: Optional[float] = None
+    kilojoules: Optional[float] = None
+    kcal: Optional[float] = None
+    average_heartrate: Optional[float] = None
+    max_heartrate: Optional[float] = None
+    hr_drift_percent: Optional[float] = None
+    vo2max_minutes: Optional[float] = None
+
+
 class NutritionEntry(BaseModel):
     food_item: str
     date: str  # Consider refining this to a date type later

--- a/src/routes.py
+++ b/src/routes.py
@@ -11,11 +11,13 @@ from .models import (
     NutritionEntry,
     StatusResponse,
     Workout,
+    WorkoutLog,
 )
 from .notion import entries_on_date, submit_to_notion
 from .nutrition import get_daily_nutrition_summaries
 from .withings import get_measurements
 from .strava import get_activities
+from .workout_notion import fetch_workouts_from_notion
 
 router: APIRouter = APIRouter(prefix="/v2")
 
@@ -58,6 +60,13 @@ async def list_workouts(
     days: int = Query(7, description="Number of days of workouts to retrieve."),
 ) -> List[Workout]:
     return await get_activities(days)
+
+
+@router.get("/workout-logs", response_model=List[WorkoutLog])
+async def list_logged_workouts(
+    days: int = Query(7, description="Number of days of logged workouts to retrieve."),
+) -> List[WorkoutLog]:
+    return await fetch_workouts_from_notion(days)
 
 @router.get("/api-schema")
 async def get_api_schema(request: Request) -> JSONResponse:

--- a/src/strava_webhook.py
+++ b/src/strava_webhook.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import base64
+import gzip
+import hmac
+import hashlib
+import json
+from typing import Any
+
+import httpx
+from fastapi import APIRouter, HTTPException, Request, Query
+
+from .config import STRAVA_CLIENT_SECRET, STRAVA_VERIFY_TOKEN
+from .strava import redis, refresh_access_token
+from .metrics import hr_drift_from_splits, vo2max_minutes
+from .workout_notion import (
+    fetch_latest_athlete_profile,
+    save_workout_to_notion,
+)
+
+webhook_router = APIRouter()
+
+
+def _verify_signature(payload: bytes, signature: str | None) -> None:
+    expected = hmac.new(
+        STRAVA_CLIENT_SECRET.encode(), payload, hashlib.sha256
+    ).hexdigest()
+    if not signature or not hmac.compare_digest(expected, signature):
+        raise HTTPException(status_code=401, detail="Invalid signature")
+
+
+@webhook_router.get("/strava-webhook", include_in_schema=False)
+async def verify_subscription(
+    hub_mode: str = Query(..., alias="hub.mode"),
+    hub_challenge: str = Query(..., alias="hub.challenge"),
+    hub_verify_token: str = Query(..., alias="hub.verify_token"),
+) -> dict[str, str]:
+    if hub_verify_token != STRAVA_VERIFY_TOKEN or hub_mode != "subscribe":
+        raise HTTPException(status_code=403, detail="Invalid verification token")
+    return {"hub.challenge": hub_challenge}
+
+
+async def _fetch_activity(activity_id: int) -> dict[str, Any]:
+    access_token = redis.get("strava_access_token")
+    if not access_token:
+        access_token = await refresh_access_token()
+        if not access_token:
+            raise HTTPException(status_code=500, detail="Auth failure")
+    headers = {"Authorization": f"Bearer {access_token}"}
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(
+            f"https://www.strava.com/api/v3/activities/{activity_id}",
+            headers=headers,
+        )
+        if resp.status_code == 401:
+            access_token = await refresh_access_token()
+            headers["Authorization"] = f"Bearer {access_token}"
+            resp = await client.get(
+                f"https://www.strava.com/api/v3/activities/{activity_id}",
+                headers=headers,
+            )
+        resp.raise_for_status()
+        return resp.json()
+
+
+async def process_activity(activity_id: int) -> None:
+    detail = await _fetch_activity(activity_id)
+    splits = detail.get("splits_metric", [])
+    athlete = await fetch_latest_athlete_profile()
+    max_hr = athlete.get("max_hr")
+    hr_drift = hr_drift_from_splits(splits)
+    vo2 = vo2max_minutes(splits, max_hr) if max_hr else 0.0
+    minified = json.dumps(detail, separators=(",", ":"))
+    compressed = gzip.compress(minified.encode("utf-8"))
+    attachment = base64.b64encode(compressed).decode("utf-8")
+    await save_workout_to_notion(detail, attachment, hr_drift, vo2)
+
+
+@webhook_router.post("/strava-webhook", include_in_schema=False)
+async def strava_event(request: Request) -> dict[str, str]:
+    body = await request.body()
+    _verify_signature(body, request.headers.get("X-Strava-Signature"))
+    event = json.loads(body)
+    if event.get("object_type") == "activity" and event.get("aspect_type") in {
+        "create",
+        "update",
+    }:
+        await process_activity(int(event["object_id"]))
+    return {"status": "ok"}


### PR DESCRIPTION
## Summary
- add configuration for workout and profile databases and Strava webhook verification
- implement Strava webhook endpoint with signature verification and activity processing
- compute HR drift and VO2 max metrics, store workouts in Notion, and expose logged workout endpoint

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b2ac5f4b0833083e24676cb2e398d