### PR TITLE
Enable upsert for Strava activity processing

### DIFF
--- a/src/strava_activity.py
+++ b/src/strava_activity.py
@@ -37,17 +37,12 @@ async def fetch_activity(activity_id: int) -> dict[str, Any]:
         return resp.json()
 
 
-async def process_activity(activity_id: int, *, update: bool = False) -> None:
+async def process_activity(activity_id: int) -> None:
     """Fetch an activity, compute metrics and upload to Notion.
 
-    Parameters
-    ----------
-    activity_id: int
-        The Strava activity identifier.
-    update: bool, optional
-        When ``True`` an existing Notion page will be updated if found. When
-        ``False`` a new page will be created. Defaults to ``False`` which
-        mirrors the previous behaviour.
+    An existing Notion page with the same activity id will be updated if
+    found; otherwise a new page will be created. This upsert behaviour helps
+    avoid duplicate entries when events are retried.
     """
     detail = await fetch_activity(activity_id)
     splits = detail.get("splits_metric", [])
@@ -79,6 +74,5 @@ async def process_activity(activity_id: int, *, update: bool = False) -> None:
         vo2,
         tss=tss,
         intensity_factor=intensity_factor,
-        update=update,
     )
 

--- a/src/strava_webhook.py
+++ b/src/strava_webhook.py
@@ -29,5 +29,6 @@ async def strava_event(request: Request) -> dict[str, str]:
     event = json.loads(body)
     aspect = event.get("aspect_type")
     if event.get("object_type") == "activity" and aspect in {"create", "update"}:
-        await process_activity(int(event["object_id"]), update=aspect == "update")
+        # Always attempt to upsert the activity to avoid duplicate Notion entries
+        await process_activity(int(event["object_id"]))
     return {"status": "ok"}

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -274,9 +274,8 @@ async def test_strava_webhook_verification() -> None:
 async def test_strava_webhook_event(monkeypatch) -> None:
     called: Dict[str, Any] = {}
 
-    async def fake_process(activity_id: int, *, update: bool = False) -> None:
+    async def fake_process(activity_id: int) -> None:
         called["id"] = activity_id
-        called["update"] = update
 
     from src import strava_webhook as webhook
 
@@ -301,16 +300,14 @@ async def test_strava_webhook_event(monkeypatch) -> None:
         )
     assert response.status_code == 200
     assert called["id"] == 42
-    assert called["update"] is False
 
 
 @pytest.mark.asyncio
 async def test_strava_webhook_event_update(monkeypatch) -> None:
     called: Dict[str, Any] = {}
 
-    async def fake_process(activity_id: int, *, update: bool = False) -> None:
+    async def fake_process(activity_id: int) -> None:
         called["id"] = activity_id
-        called["update"] = update
 
     from src import strava_webhook as webhook
 
@@ -335,7 +332,6 @@ async def test_strava_webhook_event_update(monkeypatch) -> None:
         )
     assert response.status_code == 200
     assert called["id"] == 43
-    assert called["update"] is True
 
 
 @pytest.mark.asyncio
@@ -444,7 +440,6 @@ async def test_process_activity_uses_laps_and_computes_metrics(monkeypatch) -> N
         *,
         tss: Optional[float] = None,
         intensity_factor: Optional[float] = None,
-        update: bool = False,
     ) -> None:
         called["vo2"] = vo2
         called["tss"] = tss
@@ -476,7 +471,7 @@ async def test_save_workout_to_notion_updates_existing(respx_mock: respx.MockRou
         return_value=httpx.Response(200, json={"id": "page123"})
     )
 
-    await wn.save_workout_to_notion(detail, "", 0.0, 0.0, update=True)
+    await wn.save_workout_to_notion(detail, "", 0.0, 0.0)
 
     assert patch_route.called
 
@@ -492,6 +487,6 @@ async def test_save_workout_to_notion_inserts_when_missing(respx_mock: respx.Moc
         return_value=httpx.Response(200, json={"id": "page321"})
     )
 
-    await wn.save_workout_to_notion(detail, "", 0.0, 0.0, update=True)
+    await wn.save_workout_to_notion(detail, "", 0.0, 0.0)
 
     assert post_route.called


### PR DESCRIPTION
## Summary
- default to upsert when saving Strava activities so retries don't create duplicates
- remove the superfluous `update` flag and always upsert when persisting to Notion
- adjust tests for the simplified API

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c3596e424833081049f24fe2012bb