### PR TITLE
Add athlete metrics to complex advice and parallelize data loading

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# Developer Instructions
+
+- After modifying API models or routes, regenerate the OpenAPI schema:
+  ```bash
+  python generate_openapi.py
+  ```
+  Commit the updated `openapi.json` alongside code changes.
+- Run the test suite before committing changes:
+  ```bash
+  pytest -q
+  ```

--- a/openapi.json
+++ b/openapi.json
@@ -335,6 +335,46 @@
   },
   "components": {
     "schemas": {
+      "AthleteMetrics": {
+        "properties": {
+          "ftp": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ftp"
+          },
+          "weight": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Weight"
+          },
+          "max_hr": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Hr"
+          }
+        },
+        "type": "object",
+        "title": "AthleteMetrics",
+        "description": "Latest athlete-level metrics such as FTP and max heart rate."
+      },
       "BodyMeasurement": {
         "properties": {
           "measurement_time": {
@@ -493,16 +533,20 @@
             },
             "type": "array",
             "title": "Workouts"
+          },
+          "athlete_metrics": {
+            "$ref": "#/components/schemas/AthleteMetrics"
           }
         },
         "type": "object",
         "required": [
           "nutrition",
           "metrics",
-          "workouts"
+          "workouts",
+          "athlete_metrics"
         ],
         "title": "ComplexAdvice",
-        "description": "Combined nutrition, body metrics, and workout data."
+        "description": "Combined nutrition, body metrics, workout data, and athlete metrics."
       },
       "DailyNutritionSummary": {
         "properties": {

--- a/src/models.py
+++ b/src/models.py
@@ -186,9 +186,18 @@ class DailyNutritionSummary(BaseModel):
     entries: List[NutritionEntry]
 
 
+class AthleteMetrics(BaseModel):
+    """Latest athlete-level metrics such as FTP and max heart rate."""
+
+    ftp: Optional[float] = None
+    weight: Optional[float] = None
+    max_hr: Optional[float] = None
+
+
 class ComplexAdvice(BaseModel):
-    """Combined nutrition, body metrics, and workout data."""
+    """Combined nutrition, body metrics, workout data, and athlete metrics."""
 
     nutrition: List[DailyNutritionSummary]
     metrics: List[BodyMeasurement]
     workouts: List[WorkoutLog]
+    athlete_metrics: AthleteMetrics

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -533,9 +533,13 @@ async def test_complex_advice_endpoint(monkeypatch: pytest.MonkeyPatch) -> None:
             }
         ]
 
+    async def fake_athlete() -> Dict[str, Any]:
+        return {"ftp": 250.0, "weight": 70.0, "max_hr": 190.0}
+
     monkeypatch.setattr("src.routes.get_daily_nutrition_summaries", fake_nutrition)
     monkeypatch.setattr("src.routes.get_measurements", fake_metrics)
     monkeypatch.setattr("src.routes.fetch_workouts_from_notion", fake_workouts)
+    monkeypatch.setattr("src.routes.fetch_latest_athlete_profile", fake_athlete)
 
     transport = httpx.ASGITransport(app=app)
     async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
@@ -548,3 +552,4 @@ async def test_complex_advice_endpoint(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "nutrition" in data
     assert "metrics" in data
     assert "workouts" in data
+    assert "athlete_metrics" in data


### PR DESCRIPTION
## Summary
- include athlete metrics in ComplexAdvice response model
- load nutrition, metrics, workouts, and athlete profile in parallel for faster complex advice
- cover athlete metrics in tests and OpenAPI schema
- document regenerating OpenAPI schema and running tests in repository instructions

## Testing
- `python generate_openapi.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c496a089c8330a5970267ff1aef0e