### PR TITLE
refactor: modernize settings configuration

### DIFF
--- a/src/settings.py
+++ b/src/settings.py
@@ -1,32 +1,27 @@
 from __future__ import annotations
 
 from functools import lru_cache
-from pydantic_settings import BaseSettings
-from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
     """Application settings loaded from environment variables."""
 
-    api_key: str = Field(..., env="API_KEY")
-    notion_secret: str = Field(..., env="NOTION_SECRET")
-    notion_database_id: str = Field(..., env="NOTION_DATABASE_ID")
-    notion_workout_database_id: str = Field(..., env="NOTION_WORKOUT_DATABASE_ID")
-    notion_athlete_profile_database_id: str = Field(
-        ..., env="NOTION_ATHLETE_PROFILE_DATABASE_ID"
-    )
-    strava_verify_token: str = Field(..., env="STRAVA_VERIFY_TOKEN")
-    wbsapi_url: str = Field(..., env="WBSAPI_URL")
-    upstash_redis_rest_url: str = Field(..., env="UPSTASH_REDIS_REST_URL")
-    upstash_redis_rest_token: str = Field(..., env="UPSTASH_REDIS_REST_TOKEN")
-    withings_client_id: str = Field(..., env="WITHINGS_CLIENT_ID")
-    withings_client_secret: str = Field(..., env="WITHINGS_CLIENT_SECRET")
-    strava_client_id: str = Field(..., env="STRAVA_CLIENT_ID")
-    strava_client_secret: str = Field(..., env="STRAVA_CLIENT_SECRET")
+    model_config = SettingsConfigDict(env_file=".env", case_sensitive=True)
 
-    class Config:
-        env_file = ".env"
-        case_sensitive = True
+    api_key: str
+    notion_secret: str
+    notion_database_id: str
+    notion_workout_database_id: str
+    notion_athlete_profile_database_id: str
+    strava_verify_token: str
+    wbsapi_url: str
+    upstash_redis_rest_url: str
+    upstash_redis_rest_token: str
+    withings_client_id: str
+    withings_client_secret: str
+    strava_client_id: str
+    strava_client_secret: str
 
 
 @lru_cache()


### PR DESCRIPTION
## Summary
- simplify Settings class to use pydantic v2 `SettingsConfigDict`
- rely on default env var mapping for required keys

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c8716ba648330baed5c5681a6282f