### PR TITLE
Fix environment variable case sensitivity in pydantic settings

### DIFF
--- a/src/settings.py
+++ b/src/settings.py
@@ -7,7 +7,16 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 class Settings(BaseSettings):
     """Application settings loaded from environment variables."""
 
-    model_config = SettingsConfigDict(env_file=".env", case_sensitive=True)
+    # Allow loading variables provided by the hosting environment even when
+    # they use the conventional upper-case naming. Previously `case_sensitive`
+    # was set to ``True`` which meant environment variables needed to match the
+    # exact lower-case field names (e.g. ``notion_secret``). In production the
+    # variables are defined in Render using upper-case names (e.g.
+    # ``NOTION_SECRET``), causing pydantic to treat them as missing and raise
+    # ``Field required`` errors. Disabling case sensitivity lets pydantic match
+    # these variables regardless of case, resolving the configuration loading
+    # issue when no `.env` file is present.
+    model_config = SettingsConfigDict(env_file=".env", case_sensitive=False)
 
     api_key: str
     notion_secret: str


### PR DESCRIPTION
## Summary
- allow Settings to load environment variables regardless of case
- prevent "Field required" errors when production uses upper-case env var names

## Testing
- `python generate_openapi.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c89f48eb8833081e71957d5a96596