### PR TITLE
Add health check endpoint and Render configuration

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,7 @@
+services:
+  - type: web
+    name: notion-uploader
+    env: python
+    buildCommand: pip install -r requirements.txt
+    startCommand: uvicorn src.main:app --host 0.0.0.0 --port $PORT
+    healthCheckPath: /healthz

--- a/src/main.py
+++ b/src/main.py
@@ -12,6 +12,12 @@ app: FastAPI = FastAPI(
     description="Logs food and macro data to Vit's Notion table",
 )
 
+
+@app.get("/healthz", include_in_schema=False)
+async def healthz() -> dict[str, str]:
+    """Lightweight endpoint used for health checks."""
+    return {"status": "ok"}
+
 # API endpoints secured by API key
 app.include_router(router, dependencies=[Depends(verify_api_key)])
 


### PR DESCRIPTION
## Summary
- add `/healthz` endpoint for lightweight application health checks
- configure Render to probe `/healthz` for service health

## Testing
- `python generate_openapi.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c8f4b6984833084a7d1b3f2b9cf58