### PR TITLE
Add root health endpoint

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -13,6 +13,7 @@ app: FastAPI = FastAPI(
 )
 
 
+@app.get("/", include_in_schema=False)
 @app.get("/healthz", include_in_schema=False)
 async def healthz() -> dict[str, str]:
     """Lightweight endpoint used for health checks."""


### PR DESCRIPTION
## Summary
- expose '/' health check endpoint in addition to '/healthz'
- exclude both endpoints from OpenAPI schema

## Testing
- `python generate_openapi.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c92ab2c0483309364435b201831e2