### PR TITLE
Allow HEAD requests for health endpoints

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -13,8 +13,8 @@ app: FastAPI = FastAPI(
 )
 
 
-@app.get("/", include_in_schema=False)
-@app.get("/healthz", include_in_schema=False)
+@app.api_route("/", methods=["GET", "HEAD"], include_in_schema=False)
+@app.api_route("/healthz", methods=["GET", "HEAD"], include_in_schema=False)
 async def healthz() -> dict[str, str]:
     """Lightweight endpoint used for health checks."""
     return {"status": "ok"}

--- a/tests/test_healthz.py
+++ b/tests/test_healthz.py
@@ -1,0 +1,26 @@
+import sys
+from pathlib import Path
+
+import httpx
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from src import main
+
+
+@pytest.mark.asyncio
+async def test_head_root() -> None:
+    transport = httpx.ASGITransport(app=main.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        response = await client.head("/")
+    assert response.status_code == 200
+    assert response.text == ""
+
+
+@pytest.mark.asyncio
+async def test_head_healthz() -> None:
+    transport = httpx.ASGITransport(app=main.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        response = await client.head("/healthz")
+    assert response.status_code == 200
+    assert response.text == ""


### PR DESCRIPTION
## Summary
- Allow HEAD requests on `/` and `/healthz` health endpoints
- Add tests verifying HEAD responses for root and health checks

## Testing
- `python generate_openapi.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c958bb7888330be8fd0e5c7b60744