### PR TITLE
refactor: split models into dedicated modules

### DIFF
--- a/src/metrics.py
+++ b/src/metrics.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections import deque
 from typing import Any, List, Optional
 
-from .models import BodyMeasurement, BodyMeasurementAverages
+from .models.body import BodyMeasurement, BodyMeasurementAverages
 
 
 def add_moving_average(

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -1,0 +1,16 @@
+from .body import BodyMeasurement, BodyMeasurementAverages
+from .nutrition import NutritionEntry, DailyNutritionSummary, StatusResponse
+from .workout import Workout, WorkoutLog, StravaEvent, AthleteMetrics, ComplexAdvice
+
+__all__ = [
+    'BodyMeasurement',
+    'BodyMeasurementAverages',
+    'NutritionEntry',
+    'DailyNutritionSummary',
+    'StatusResponse',
+    'Workout',
+    'WorkoutLog',
+    'StravaEvent',
+    'AthleteMetrics',
+    'ComplexAdvice',
+]

--- a/src/models/body.py
+++ b/src/models/body.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class BodyMeasurementAverages(BaseModel):
+    """7-day moving averages for body measurements."""
+
+    weight_kg: float = Field(
+        ..., description="7-day average of body weight in kilograms"
+    )
+    fat_mass_kg: float = Field(
+        ..., description="7-day average of total fat mass in kilograms"
+    )
+    muscle_mass_kg: float = Field(
+        ..., description="7-day average of skeletal muscle mass in kilograms"
+    )
+    bone_mass_kg: float = Field(
+        ..., description="7-day average of bone mass in kilograms"
+    )
+    hydration_kg: float = Field(
+        ..., description="7-day average of body water content in kilograms"
+    )
+    fat_free_mass_kg: float = Field(
+        ..., description="7-day average of fat-free mass (muscles, bones, tissues) in kilograms"
+    )
+    body_fat_percent: float = Field(
+        ..., description="7-day average of body fat percentage"
+    )
+
+
+class BodyMeasurement(BaseModel):
+    """A human-readable representation of body measurements from a smart scale."""
+
+    measurement_time: datetime
+    weight_kg: float = Field(..., description="Body weight in kilograms")
+    fat_mass_kg: float = Field(..., description="Total fat mass in kilograms")
+    muscle_mass_kg: float = Field(..., description="Skeletal muscle mass in kilograms")
+    bone_mass_kg: float = Field(..., description="Bone mass in kilograms")
+    hydration_kg: float = Field(..., description="Body water content in kilograms")
+    fat_free_mass_kg: float = Field(
+        ..., description="Fat-free mass (muscles, bones, tissues) in kilograms"
+    )
+    body_fat_percent: float = Field(..., description="Body fat percentage")
+    device_name: str = Field(..., description="Name of the measuring device")
+    moving_average_7d: Optional[BodyMeasurementAverages] = Field(
+        None, description="7-day moving averages for the measurement metrics"
+    )
+
+    class Config:
+        json_schema_extra = {
+            "example": {
+                "measurement_time": "2025-08-09T08:01:06",
+                "weight_kg": 68.816,
+                "fat_mass_kg": 14.80,
+                "muscle_mass_kg": 51.27,
+                "bone_mass_kg": 3.845,
+                "hydration_kg": 54.016,
+                "fat_free_mass_kg": 21.507,
+                "body_fat_percent": 21.5,
+                "device_name": "Withings Body+",
+            }
+        }

--- a/src/models/nutrition.py
+++ b/src/models/nutrition.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from typing import Literal, List
+
+from pydantic import BaseModel, Field
+
+
+class NutritionEntry(BaseModel):
+    food_item: str
+    date: str  # Consider refining this to a date type later
+    calories: int
+    protein_g: float
+    carbs_g: float
+    fat_g: float
+    meal_type: Literal[
+        "Breakfast", "Lunch", "Dinner", "Snack", "Pre-workout", "Post-workout"
+    ]
+    notes: str = Field(..., min_length=1)
+
+
+class StatusResponse(BaseModel):
+    """Simple response model indicating operation status."""
+
+    status: str
+
+
+class DailyNutritionSummary(BaseModel):
+    """Aggregated nutrition information for a single day."""
+
+    date: str
+    calories: int
+    protein_g: float
+    carbs_g: float
+    fat_g: float
+    entries: List[NutritionEntry]

--- a/src/models/workout.py
+++ b/src/models/workout.py
@@ -1,67 +1,12 @@
 from __future__ import annotations
 
-from pydantic import BaseModel, Field
-from typing import Literal, List, Optional, Dict, Any
 from datetime import datetime
+from typing import Optional, Dict, Any, List
 
-class BodyMeasurementAverages(BaseModel):
-    """7-day moving averages for body measurements."""
+from pydantic import BaseModel, Field
 
-    weight_kg: float = Field(
-        ..., description="7-day average of body weight in kilograms"
-    )
-    fat_mass_kg: float = Field(
-        ..., description="7-day average of total fat mass in kilograms"
-    )
-    muscle_mass_kg: float = Field(
-        ..., description="7-day average of skeletal muscle mass in kilograms"
-    )
-    bone_mass_kg: float = Field(
-        ..., description="7-day average of bone mass in kilograms"
-    )
-    hydration_kg: float = Field(
-        ..., description="7-day average of body water content in kilograms"
-    )
-    fat_free_mass_kg: float = Field(
-        ..., description="7-day average of fat-free mass (muscles, bones, tissues) in kilograms"
-    )
-    body_fat_percent: float = Field(
-        ..., description="7-day average of body fat percentage"
-    )
-
-
-class BodyMeasurement(BaseModel):
-    """A human-readable representation of body measurements from a smart scale."""
-
-    measurement_time: datetime
-    weight_kg: float = Field(..., description="Body weight in kilograms")
-    fat_mass_kg: float = Field(..., description="Total fat mass in kilograms")
-    muscle_mass_kg: float = Field(..., description="Skeletal muscle mass in kilograms")
-    bone_mass_kg: float = Field(..., description="Bone mass in kilograms")
-    hydration_kg: float = Field(..., description="Body water content in kilograms")
-    fat_free_mass_kg: float = Field(
-        ..., description="Fat-free mass (muscles, bones, tissues) in kilograms"
-    )
-    body_fat_percent: float = Field(..., description="Body fat percentage")
-    device_name: str = Field(..., description="Name of the measuring device")
-    moving_average_7d: Optional[BodyMeasurementAverages] = Field(
-        None, description="7-day moving averages for the measurement metrics"
-    )
-
-    class Config:
-        json_schema_extra = {
-            "example": {
-                "measurement_time": "2025-08-09T08:01:06",
-                "weight_kg": 68.816,
-                "fat_mass_kg": 14.80,
-                "muscle_mass_kg": 51.27,
-                "bone_mass_kg": 3.845,
-                "hydration_kg": 54.016,
-                "fat_free_mass_kg": 21.507,
-                "body_fat_percent": 21.5,
-                "device_name": "Withings Body+"
-            }
-        }
+from .body import BodyMeasurement
+from .nutrition import DailyNutritionSummary
 
 
 class Workout(BaseModel):
@@ -154,36 +99,6 @@ class WorkoutLog(BaseModel):
     tss: Optional[float] = None
     intensity_factor: Optional[float] = None
     notes: Optional[str] = None
-
-
-class NutritionEntry(BaseModel):
-    food_item: str
-    date: str  # Consider refining this to a date type later
-    calories: int
-    protein_g: float
-    carbs_g: float
-    fat_g: float
-    meal_type: Literal[
-        "Breakfast", "Lunch", "Dinner", "Snack", "Pre-workout", "Post-workout"
-    ]
-    notes: str = Field(..., min_length=1)
-
-
-class StatusResponse(BaseModel):
-    """Simple response model indicating operation status."""
-
-    status: str
-
-
-class DailyNutritionSummary(BaseModel):
-    """Aggregated nutrition information for a single day."""
-
-    date: str
-    calories: int
-    protein_g: float
-    carbs_g: float
-    fat_g: float
-    entries: List[NutritionEntry]
 
 
 class AthleteMetrics(BaseModel):

--- a/src/notion.py
+++ b/src/notion.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Optional
 import httpx
 from fastapi import HTTPException
 
-from .models import NutritionEntry, StatusResponse
+from .models.nutrition import NutritionEntry, StatusResponse
 from .settings import Settings
 
 async def submit_to_notion(entry: NutritionEntry, settings: Settings) -> StatusResponse:

--- a/src/nutrition.py
+++ b/src/nutrition.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections import defaultdict
 from typing import Dict, List
 
-from .models import DailyNutritionSummary, NutritionEntry
+from .models.nutrition import DailyNutritionSummary, NutritionEntry
 from .notion import entries_in_range
 from .settings import Settings
 

--- a/src/routes.py
+++ b/src/routes.py
@@ -7,14 +7,13 @@ import asyncio
 from fastapi import APIRouter, Path, Query, Request, Depends
 from fastapi.responses import JSONResponse
 
-from .models import (
-    BodyMeasurement,
-    ComplexAdvice,
+from .models.body import BodyMeasurement
+from .models.nutrition import (
     DailyNutritionSummary,
     NutritionEntry,
     StatusResponse,
-    WorkoutLog,
 )
+from .models.workout import ComplexAdvice, WorkoutLog
 from .notion import entries_on_date, submit_to_notion
 from .nutrition import get_daily_nutrition_summaries
 from .withings import get_measurements

--- a/src/withings.py
+++ b/src/withings.py
@@ -3,7 +3,7 @@ from typing import Dict, Any, Optional, List
 import httpx
 from upstash_redis import Redis
 from datetime import datetime
-from .models import BodyMeasurement
+from .models.body import BodyMeasurement
 from .metrics import add_moving_average
 from .settings import Settings
 

--- a/src/workout_notion.py
+++ b/src/workout_notion.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Optional
 
 import httpx
 
-from .models import WorkoutLog
+from .models.workout import WorkoutLog
 from .settings import Settings
 
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -8,7 +8,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from src.metrics import add_moving_average
-from src.models import BodyMeasurement
+from src.models.body import BodyMeasurement
 
 
 def make_measurement(day: int, value: float | None) -> BodyMeasurement:


### PR DESCRIPTION
## Summary
- refactor models into body, nutrition, and workout modules under `src/models`
- update imports across application and tests
- regenerate OpenAPI schema

## Testing
- `python generate_openapi.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c82c3fed08330b230c76424945d1a