### PR TITLE
Support configurable local time context

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -91,6 +91,18 @@
               "title": "Date"
             },
             "description": "Date to fetch in YYYY-MM-DD format."
+          },
+          {
+            "name": "timezone",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "IANA timezone for local time, defaults to Prague.",
+              "default": "Europe/Prague",
+              "title": "Timezone"
+            },
+            "description": "IANA timezone for local time, defaults to Prague."
           }
         ],
         "responses": {
@@ -99,11 +111,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/NutritionEntry"
-                  },
-                  "title": "Response List Daily Nutrition Entries V2 Nutrition Entries Daily  Date  Get"
+                  "$ref": "#/components/schemas/NutritionEntriesResponse"
                 }
               }
             }
@@ -152,6 +160,18 @@
               "title": "End Date"
             },
             "description": "End date (inclusive) in YYYY-MM-DD format."
+          },
+          {
+            "name": "timezone",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "IANA timezone for local time, defaults to Prague.",
+              "default": "Europe/Prague",
+              "title": "Timezone"
+            },
+            "description": "IANA timezone for local time, defaults to Prague."
           }
         ],
         "responses": {
@@ -160,11 +180,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/DailyNutritionSummary"
-                  },
-                  "title": "Response List Nutrition Entries By Period V2 Nutrition Entries Period Get"
+                  "$ref": "#/components/schemas/NutritionPeriodResponse"
                 }
               }
             }
@@ -306,6 +322,18 @@
               "title": "Days"
             },
             "description": "Number of days of data to retrieve."
+          },
+          {
+            "name": "timezone",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "IANA timezone for local time, defaults to Prague.",
+              "default": "Europe/Prague",
+              "title": "Timezone"
+            },
+            "description": "IANA timezone for local time, defaults to Prague."
           }
         ],
         "responses": {
@@ -513,6 +541,22 @@
       },
       "ComplexAdvice": {
         "properties": {
+          "local_time": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Local Time",
+            "description": "Current local time with timezone"
+          },
+          "part_of_day": {
+            "type": "string",
+            "enum": [
+              "night",
+              "morning",
+              "afternoon",
+              "evening"
+            ],
+            "title": "Part Of Day"
+          },
           "nutrition": {
             "items": {
               "$ref": "#/components/schemas/DailyNutritionSummary"
@@ -540,6 +584,8 @@
         },
         "type": "object",
         "required": [
+          "local_time",
+          "part_of_day",
           "nutrition",
           "metrics",
           "workouts",
@@ -603,6 +649,41 @@
         "type": "object",
         "title": "HTTPValidationError"
       },
+      "NutritionEntriesResponse": {
+        "properties": {
+          "local_time": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Local Time",
+            "description": "Current local time with timezone"
+          },
+          "part_of_day": {
+            "type": "string",
+            "enum": [
+              "night",
+              "morning",
+              "afternoon",
+              "evening"
+            ],
+            "title": "Part Of Day"
+          },
+          "entries": {
+            "items": {
+              "$ref": "#/components/schemas/NutritionEntry"
+            },
+            "type": "array",
+            "title": "Entries"
+          }
+        },
+        "type": "object",
+        "required": [
+          "local_time",
+          "part_of_day",
+          "entries"
+        ],
+        "title": "NutritionEntriesResponse",
+        "description": "Response wrapper for a list of nutrition entries with timing context."
+      },
       "NutritionEntry": {
         "properties": {
           "food_item": {
@@ -659,6 +740,41 @@
           "notes"
         ],
         "title": "NutritionEntry"
+      },
+      "NutritionPeriodResponse": {
+        "properties": {
+          "local_time": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Local Time",
+            "description": "Current local time with timezone"
+          },
+          "part_of_day": {
+            "type": "string",
+            "enum": [
+              "night",
+              "morning",
+              "afternoon",
+              "evening"
+            ],
+            "title": "Part Of Day"
+          },
+          "nutrition": {
+            "items": {
+              "$ref": "#/components/schemas/DailyNutritionSummary"
+            },
+            "type": "array",
+            "title": "Nutrition"
+          }
+        },
+        "type": "object",
+        "required": [
+          "local_time",
+          "part_of_day",
+          "nutrition"
+        ],
+        "title": "NutritionPeriodResponse",
+        "description": "Response wrapper for a range of daily nutrition summaries with timing context."
       },
       "StatusResponse": {
         "properties": {

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -1,6 +1,13 @@
 from .body import BodyMeasurement, BodyMeasurementAverages
-from .nutrition import NutritionEntry, DailyNutritionSummary, StatusResponse
+from .nutrition import (
+    NutritionEntry,
+    DailyNutritionSummary,
+    StatusResponse,
+    NutritionEntriesResponse,
+    NutritionPeriodResponse,
+)
 from .workout import Workout, WorkoutLog, StravaEvent, AthleteMetrics, ComplexAdvice
+from .time import TimeContext
 
 __all__ = [
     'BodyMeasurement',
@@ -8,6 +15,9 @@ __all__ = [
     'NutritionEntry',
     'DailyNutritionSummary',
     'StatusResponse',
+    'NutritionEntriesResponse',
+    'NutritionPeriodResponse',
+    'TimeContext',
     'Workout',
     'WorkoutLog',
     'StravaEvent',

--- a/src/models/nutrition.py
+++ b/src/models/nutrition.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Literal, List
 
+from .time import TimeContext
+
 from pydantic import BaseModel, Field
 
 
@@ -33,3 +35,15 @@ class DailyNutritionSummary(BaseModel):
     carbs_g: float
     fat_g: float
     entries: List[NutritionEntry]
+
+
+class NutritionEntriesResponse(TimeContext):
+    """Response wrapper for a list of nutrition entries with timing context."""
+
+    entries: List[NutritionEntry]
+
+
+class NutritionPeriodResponse(TimeContext):
+    """Response wrapper for a range of daily nutrition summaries with timing context."""
+
+    nutrition: List[DailyNutritionSummary]

--- a/src/models/time.py
+++ b/src/models/time.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal, Tuple
+from zoneinfo import ZoneInfo
+
+from pydantic import BaseModel, Field
+
+
+class TimeContext(BaseModel):
+    """Mixin providing local time and part of day information."""
+
+    local_time: datetime = Field(..., description="Current local time with timezone")
+    part_of_day: Literal["night", "morning", "afternoon", "evening"]
+
+
+def get_local_time(timezone: str = "Europe/Prague") -> Tuple[datetime, str]:
+    """Return current local time and a human-friendly part of day.
+
+    Args:
+        timezone: IANA timezone string, defaults to "Europe/Prague".
+
+    Returns:
+        Tuple of current localized datetime and part of day string.
+    """
+
+    now: datetime = datetime.now(ZoneInfo(timezone))
+    hour: int = now.hour
+    if 5 <= hour < 12:
+        part = "morning"
+    elif 12 <= hour < 17:
+        part = "afternoon"
+    elif 17 <= hour < 22:
+        part = "evening"
+    else:
+        part = "night"
+    return now, part

--- a/src/models/workout.py
+++ b/src/models/workout.py
@@ -5,6 +5,8 @@ from typing import Optional, Dict, Any, List
 
 from pydantic import BaseModel, Field
 
+from .time import TimeContext
+
 from .body import BodyMeasurement
 from .nutrition import DailyNutritionSummary
 
@@ -109,7 +111,7 @@ class AthleteMetrics(BaseModel):
     max_hr: Optional[float] = None
 
 
-class ComplexAdvice(BaseModel):
+class ComplexAdvice(TimeContext):
     """Combined nutrition, body metrics, workout data, and athlete metrics."""
 
     nutrition: List[DailyNutritionSummary]

--- a/src/routes/utils.py
+++ b/src/routes/utils.py
@@ -1,0 +1,6 @@
+from fastapi import Query
+
+timezone_query = Query(
+    default="Europe/Prague",
+    description="IANA timezone for local time, defaults to Prague.",
+)


### PR DESCRIPTION
## Summary
- Ensure returned `local_time` includes timezone offset and document it
- Deduplicate timezone query parameter using shared `timezone_query`
- Update tests and OpenAPI schema accordingly

## Testing
- `python generate_openapi.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689cb04b25688330926a5e54f1e0e1ad