### PR TITLE
chore: remove unused imports and update instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,3 +9,7 @@
   ```bash
   pytest -q
   ```
+- As a recurring chore, remove unused imports and keep `requirements.txt` up to date:
+  ```bash
+  ruff check --select F401 src tests
+  ```

--- a/src/strava_webhook.py
+++ b/src/strava_webhook.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import hmac
-import hashlib
 import json
 
 from fastapi import APIRouter, HTTPException, Request, Query, Depends

--- a/src/withings.py
+++ b/src/withings.py
@@ -1,5 +1,5 @@
 import time
-from typing import Dict, Any, Optional, List
+from typing import Optional, List
 import httpx
 from upstash_redis import Redis
 from datetime import datetime

--- a/tests/test_vo2max.py
+++ b/tests/test_vo2max.py
@@ -1,5 +1,4 @@
-import pytest
-from typing import List, Dict, Any
+from typing import Dict, Any
 from src.metrics import vo2max_minutes
 
 


### PR DESCRIPTION
## Summary
- drop unused imports across code and tests
- document recurring cleanup chore in AGENTS instructions

## Testing
- `ruff check --select F401 src tests`
- `python generate_openapi.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ccfedfaec83308a3024abbabd0ef1