### PR TITLE
refactor: inject redis dependencies

### DIFF
--- a/src/redis.py
+++ b/src/redis.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from typing import Protocol, Optional
+
+from fastapi import Depends
+from upstash_redis import Redis
+
+from .settings import Settings, get_settings
+
+
+class RedisClient(Protocol):
+    """Minimal Redis client interface used by the application."""
+
+    def get(self, key: str) -> Optional[str]:
+        ...
+
+    def set(self, key: str, value: str, ex: int | None = None) -> None:
+        ...
+
+
+def get_redis(settings: Settings = Depends(get_settings)) -> RedisClient:
+    """Factory helper that provides a Redis client instance."""
+
+    return Redis(url=settings.upstash_redis_rest_url, token=settings.upstash_redis_rest_token)

--- a/src/routes/metrics.py
+++ b/src/routes/metrics.py
@@ -5,6 +5,7 @@ from typing import List
 from fastapi import APIRouter, Query, Depends
 
 from ..models.body import BodyMeasurement
+from ..redis import RedisClient, get_redis
 from ..settings import Settings, get_settings
 from ..withings import get_measurements
 
@@ -14,7 +15,8 @@ router: APIRouter = APIRouter()
 @router.get("/body-measurements", response_model=List[BodyMeasurement])
 async def list_body_measurements(
     days: int = Query(7, description="Number of days of measurements to retrieve."),
+    redis: RedisClient = Depends(get_redis),
     settings: Settings = Depends(get_settings),
 ) -> List[BodyMeasurement]:
     """Get body measurements from Withings scale for the specified number of days."""
-    return await get_measurements(days, settings)
+    return await get_measurements(days, redis, settings)

--- a/src/routes/strava.py
+++ b/src/routes/strava.py
@@ -4,6 +4,7 @@ from typing import Dict
 
 from fastapi import APIRouter, Depends
 
+from ..redis import RedisClient, get_redis
 from ..settings import Settings, get_settings
 from ..strava_activity import process_activity
 
@@ -12,7 +13,9 @@ router: APIRouter = APIRouter()
 
 @router.post("/strava-activity/{activity_id}", include_in_schema=False)
 async def trigger_strava_processing(
-    activity_id: int, settings: Settings = Depends(get_settings)
+    activity_id: int,
+    redis: RedisClient = Depends(get_redis),
+    settings: Settings = Depends(get_settings),
 ) -> Dict[str, str]:
-    await process_activity(activity_id, settings)
+    await process_activity(activity_id, redis, settings)
     return {"status": "ok"}

--- a/src/strava.py
+++ b/src/strava.py
@@ -1,17 +1,13 @@
 from typing import Optional
 
 import httpx
-from upstash_redis import Redis
+
+from .redis import RedisClient
 from .settings import Settings
 
 
-def get_redis(settings: Settings) -> Redis:
-    return Redis(url=settings.upstash_redis_rest_url, token=settings.upstash_redis_rest_token)
-
-
-async def refresh_access_token(settings: Settings) -> Optional[str]:
+async def refresh_access_token(redis: RedisClient, settings: Settings) -> Optional[str]:
     """Refresh the Strava access token using the refresh token stored in Redis."""
-    redis = get_redis(settings)
     refresh_token = redis.get("strava_refresh_token")
     if not refresh_token:
         raise ValueError("No Strava refresh token found in Redis")

--- a/src/strava_webhook.py
+++ b/src/strava_webhook.py
@@ -4,6 +4,7 @@ import json
 
 from fastapi import APIRouter, HTTPException, Request, Query, Depends
 
+from .redis import RedisClient, get_redis
 from .settings import Settings, get_settings
 from .strava_activity import process_activity
 
@@ -24,12 +25,14 @@ async def verify_subscription(
 
 @webhook_router.post("/strava-webhook", include_in_schema=False)
 async def strava_event(
-    request: Request, settings: Settings = Depends(get_settings)
+    request: Request,
+    redis: RedisClient = Depends(get_redis),
+    settings: Settings = Depends(get_settings),
 ) -> dict[str, str]:
     body = await request.body()
     event = json.loads(body)
     aspect = event.get("aspect_type")
     if event.get("object_type") == "activity" and aspect in {"create", "update"}:
         # Always attempt to upsert the activity to avoid duplicate Notion entries
-        await process_activity(int(event["object_id"]), settings)
+        await process_activity(int(event["object_id"]), redis, settings)
     return {"status": "ok"}


### PR DESCRIPTION
## Summary
- add RedisClient protocol and `get_redis` factory
- require a Redis instance for Strava and Withings operations
- pass Redis dependency through FastAPI routes and tests

## Testing
- `ruff check --select F401 src tests`
- `python generate_openapi.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d97d23fac8330910b1a927a345980