### PR TITLE
refactor: introduce Notion and Redis services

### DIFF
--- a/src/notion.py
+++ b/src/notion.py
@@ -2,19 +2,14 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional
 
-import httpx
-from fastapi import HTTPException
-
 from .models.nutrition import NutritionEntry, StatusResponse
+from .services.notion import NotionClient
 from .settings import Settings
 
-async def submit_to_notion(entry: NutritionEntry, settings: Settings) -> StatusResponse:
+async def submit_to_notion(
+    entry: NutritionEntry, settings: Settings, client: NotionClient
+) -> StatusResponse:
     """Create a page in the configured Notion database for the entry."""
-    headers = {
-        "Authorization": f"Bearer {settings.notion_secret}",
-        "Content-Type": "application/json",
-        "Notion-Version": "2022-06-28",
-    }
     payload: Dict[str, Any] = {
         "parent": {"database_id": settings.notion_database_id},
         "properties": {
@@ -28,17 +23,7 @@ async def submit_to_notion(entry: NutritionEntry, settings: Settings) -> StatusR
             "Notes": {"rich_text": [{"text": {"content": entry.notes}}]},
         },
     }
-    try:
-        async with httpx.AsyncClient(timeout=30.0) as client:
-            response: httpx.Response = await client.post(
-                "https://api.notion.com/v1/pages",
-                json=payload,
-                headers=headers,
-            )
-    except httpx.ReadTimeout as exc:  # pragma: no cover - network failure
-        raise HTTPException(status_code=504, detail="Request to Notion timed out") from exc
-    if response.status_code != 200:
-        raise HTTPException(status_code=response.status_code, detail=response.text)
+    await client.create(payload)
     return StatusResponse(status="success")
 
 def parse_page(page: Dict[str, Any]) -> Optional[NutritionEntry]:
@@ -64,26 +49,11 @@ def parse_page(page: Dict[str, Any]) -> Optional[NutritionEntry]:
         return None
 
 async def query_entries(
-    filter_payload: Dict[str, Any], settings: Settings
+    filter_payload: Dict[str, Any], settings: Settings, client: NotionClient
 ) -> List[NutritionEntry]:
-    notion_url: str = f"https://api.notion.com/v1/databases/{settings.notion_database_id}/query"
-    headers = {
-        "Authorization": f"Bearer {settings.notion_secret}",
-        "Content-Type": "application/json",
-        "Notion-Version": "2022-06-28",
-    }
-    try:
-        async with httpx.AsyncClient(timeout=30.0) as client:
-            response: httpx.Response = await client.post(
-                notion_url,
-                json={"filter": filter_payload},
-                headers=headers,
-            )
-    except httpx.ReadTimeout as exc:  # pragma: no cover - network failure
-        raise HTTPException(status_code=504, detail="Request to Notion timed out") from exc
-    if response.status_code != 200:
-        raise HTTPException(status_code=response.status_code, detail=response.text)
-    results: List[Dict[str, Any]] = response.json().get("results", [])
+    results: List[Dict[str, Any]] = await client.query(
+        settings.notion_database_id, {"filter": filter_payload}
+    )
     entries: List[NutritionEntry] = []
     for page in results:
         entry: Optional[NutritionEntry] = parse_page(page)
@@ -91,13 +61,18 @@ async def query_entries(
             entries.append(entry)
     return entries
 
-async def entries_on_date(date: str, settings: Settings) -> List[NutritionEntry]:
+async def entries_on_date(
+    date: str, settings: Settings, client: NotionClient
+) -> List[NutritionEntry]:
     return await query_entries(
-        {"property": "Date", "date": {"equals": date}}, settings
+        {"property": "Date", "date": {"equals": date}}, settings, client
     )
 
 async def entries_in_range(
-    start_date: str, end_date: str, settings: Settings
+    start_date: str,
+    end_date: str,
+    settings: Settings,
+    client: NotionClient,
 ) -> List[NutritionEntry]:
     return await query_entries(
         {
@@ -107,4 +82,5 @@ async def entries_in_range(
             ]
         },
         settings,
+        client,
     )

--- a/src/nutrition.py
+++ b/src/nutrition.py
@@ -5,14 +5,17 @@ from typing import Dict, List
 
 from .models.nutrition import DailyNutritionSummary, NutritionEntry
 from .notion import entries_in_range
+from .services.notion import NotionClient
 from .settings import Settings
 
 
 async def get_daily_nutrition_summaries(
-    start_date: str, end_date: str, settings: Settings
+    start_date: str, end_date: str, settings: Settings, client: NotionClient
 ) -> List[DailyNutritionSummary]:
     """Retrieve nutrition entries for a date range and aggregate by day."""
-    entries: List[NutritionEntry] = await entries_in_range(start_date, end_date, settings)
+    entries: List[NutritionEntry] = await entries_in_range(
+        start_date, end_date, settings, client
+    )
     grouped: Dict[str, List[NutritionEntry]] = defaultdict(list)
     for entry in entries:
         grouped[entry.date].append(entry)

--- a/src/routes/metrics.py
+++ b/src/routes/metrics.py
@@ -5,7 +5,7 @@ from typing import List
 from fastapi import APIRouter, Query, Depends
 
 from ..models.body import BodyMeasurement
-from ..redis import RedisClient, get_redis
+from ..services.redis import RedisClient, get_redis
 from ..settings import Settings, get_settings
 from ..withings import get_measurements
 

--- a/src/routes/strava.py
+++ b/src/routes/strava.py
@@ -4,7 +4,8 @@ from typing import Dict
 
 from fastapi import APIRouter, Depends
 
-from ..redis import RedisClient, get_redis
+from ..services.redis import RedisClient, get_redis
+from ..services.notion import NotionClient, get_notion_client
 from ..settings import Settings, get_settings
 from ..strava_activity import process_activity
 
@@ -16,6 +17,7 @@ async def trigger_strava_processing(
     activity_id: int,
     redis: RedisClient = Depends(get_redis),
     settings: Settings = Depends(get_settings),
+    client: NotionClient = Depends(get_notion_client),
 ) -> Dict[str, str]:
-    await process_activity(activity_id, redis, settings)
+    await process_activity(activity_id, redis, settings, client)
     return {"status": "ok"}

--- a/src/routes/workouts.py
+++ b/src/routes/workouts.py
@@ -9,7 +9,8 @@ from fastapi import APIRouter, Query, Depends
 from ..models.workout import ComplexAdvice, WorkoutLog
 from ..models.time import get_local_time
 from ..nutrition import get_daily_nutrition_summaries
-from ..redis import RedisClient, get_redis
+from ..services.notion import NotionClient, get_notion_client
+from ..services.redis import RedisClient, get_redis
 from ..settings import Settings, get_settings
 from ..withings import get_measurements
 from ..workout_notion import (
@@ -25,8 +26,9 @@ router: APIRouter = APIRouter()
 async def list_logged_workouts(
     days: int = Query(7, description="Number of days of logged workouts to retrieve."),
     settings: Settings = Depends(get_settings),
+    client: NotionClient = Depends(get_notion_client),
 ) -> List[WorkoutLog]:
-    return await fetch_workouts_from_notion(days, settings)
+    return await fetch_workouts_from_notion(days, settings, client)
 
 
 @router.get("/complex-advice", response_model=ComplexAdvice)
@@ -35,13 +37,16 @@ async def get_complex_advice(
     timezone: str = timezone_query,
     redis: RedisClient = Depends(get_redis),
     settings: Settings = Depends(get_settings),
+    client: NotionClient = Depends(get_notion_client),
 ) -> ComplexAdvice:
     end: date = date.today()
     start: date = end - timedelta(days=days - 1)
-    nutrition_coro = get_daily_nutrition_summaries(start.isoformat(), end.isoformat(), settings)
+    nutrition_coro = get_daily_nutrition_summaries(
+        start.isoformat(), end.isoformat(), settings, client
+    )
     metrics_coro = get_measurements(days, redis, settings)
-    workouts_coro = fetch_workouts_from_notion(days, settings)
-    athlete_coro = fetch_latest_athlete_profile(settings)
+    workouts_coro = fetch_workouts_from_notion(days, settings, client)
+    athlete_coro = fetch_latest_athlete_profile(settings, client)
     nutrition, metrics, workouts, athlete_metrics = await asyncio.gather(
         nutrition_coro, metrics_coro, workouts_coro, athlete_coro
     )

--- a/src/services/notion.py
+++ b/src/services/notion.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+import httpx
+from fastapi import Depends, HTTPException
+
+from ..settings import Settings, get_settings
+
+
+class NotionClient:
+    """Minimal Notion HTTP client with shared error handling."""
+
+    def __init__(self, *, settings: Settings) -> None:
+        self._base_url: str = "https://api.notion.com/v1"
+        self._headers: Dict[str, str] = {
+            "Authorization": f"Bearer {settings.notion_secret}",
+            "Content-Type": "application/json",
+            "Notion-Version": "2022-06-28",
+        }
+        self._timeout: float = 30.0
+
+    async def _request(self, method: str, path: str, **kwargs: Any) -> httpx.Response:
+        url = f"{self._base_url}{path}"
+        try:
+            async with httpx.AsyncClient(timeout=self._timeout) as client:
+                resp = await client.request(method, url, headers=self._headers, **kwargs)
+        except httpx.ReadTimeout as exc:  # pragma: no cover - network failure
+            raise HTTPException(status_code=504, detail="Request to Notion timed out") from exc
+        if resp.status_code != 200:
+            raise HTTPException(status_code=resp.status_code, detail=resp.text)
+        return resp
+
+    async def query(self, database_id: str, payload: Dict[str, Any]) -> List[Dict[str, Any]]:
+        resp = await self._request("POST", f"/databases/{database_id}/query", json=payload)
+        return resp.json().get("results", [])
+
+    async def create(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        resp = await self._request("POST", "/pages", json=payload)
+        return resp.json()
+
+    async def update(self, page_id: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+        resp = await self._request("PATCH", f"/pages/{page_id}", json=payload)
+        return resp.json()
+
+
+def get_notion_client(settings: Settings = Depends(get_settings)) -> NotionClient:
+    """Dependency that provides a configured :class:`NotionClient` instance."""
+
+    return NotionClient(settings=settings)

--- a/src/services/redis.py
+++ b/src/services/redis.py
@@ -5,7 +5,7 @@ from typing import Protocol, Optional
 from fastapi import Depends
 from upstash_redis import Redis
 
-from .settings import Settings, get_settings
+from ..settings import Settings, get_settings
 
 
 class RedisClient(Protocol):

--- a/src/strava.py
+++ b/src/strava.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 import httpx
 
-from .redis import RedisClient
+from .services.redis import RedisClient
 from .settings import Settings
 
 

--- a/src/withings.py
+++ b/src/withings.py
@@ -5,7 +5,7 @@ from datetime import datetime
 
 from .models.body import BodyMeasurement
 from .metrics import add_moving_average
-from .redis import RedisClient
+from .services.redis import RedisClient
 from .settings import Settings
 
 


### PR DESCRIPTION
## Summary
- add shared `NotionClient` with query/create/update helpers
- move redis access into `services` package
- refactor routes and helpers to use injected clients

## Testing
- `ruff check --select F401 src tests`
- `pytest -q`
- `python generate_openapi.py`

------
https://chatgpt.com/codex/tasks/task_e_689da3a1def4833091ec60192ed18ae6