### PR TITLE
Require minimum values for rolling average

### DIFF
--- a/src/metrics.py
+++ b/src/metrics.py
@@ -13,9 +13,9 @@ def add_moving_average(
 
     Measurements are first sorted by ``measurement_time`` and a simple moving
     average is computed for each metric. ``None`` values are ignored so missing
-    data does not dilute the average. A moving average is always calculated
-    from the values available within the ``window`` size, even if fewer than
-    ``window`` non-missing values are present.
+    data does not dilute the average. A moving average is only calculated when
+    at least three non-missing values are present in the current window for
+    every metric.
 
     Args:
         measurements: Raw body measurements.
@@ -24,7 +24,7 @@ def add_moving_average(
 
     Returns:
         The list of measurements with ``moving_average_7d`` populated when all
-        metrics have at least one non-missing value in the current window.
+        metrics have at least three non-missing values in the current window.
     """
 
     metrics = [
@@ -42,6 +42,7 @@ def add_moving_average(
     )
     queues = {metric: deque(maxlen=window) for metric in metrics}
 
+    min_values = 3
     for m in sorted_measurements:
         for metric in metrics:
             queues[metric].append(getattr(m, metric))
@@ -49,7 +50,7 @@ def add_moving_average(
         averages: dict[str, float] = {}
         for metric in metrics:
             values = [v for v in queues[metric] if v is not None]
-            if values:
+            if len(values) >= min_values:
                 averages[metric] = sum(values) / len(values)
             else:
                 break

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -27,12 +27,22 @@ def make_measurement(day: int, value: float | None) -> BodyMeasurement:
     )
 
 
-def test_add_moving_average_partial_window() -> None:
+def test_add_moving_average_requires_three_values() -> None:
     measurements = [make_measurement(1, 10), make_measurement(2, 20)]
+    result = add_moving_average(measurements)
+    assert result[-1].moving_average_7d is None
+
+
+def test_add_moving_average_after_three_values() -> None:
+    measurements = [
+        make_measurement(1, 10),
+        make_measurement(2, 20),
+        make_measurement(3, 30),
+    ]
     result = add_moving_average(measurements)
     avg = result[-1].moving_average_7d
     assert avg is not None
-    assert avg.weight_kg == pytest.approx(15.0)
+    assert avg.weight_kg == pytest.approx(20.0)
 
 
 def test_add_moving_average_excludes_missing_values() -> None:


### PR DESCRIPTION
## Summary
- require at least three data points before emitting 7‑day moving averages
- add tests verifying minimum count logic and existing behavior with missing values

## Testing
- `ruff check --select F401 src tests`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689dc564a6a0833085c6fb0a03c3f830