### PR TITLE
introduce api client interfaces

### DIFF
--- a/src/notion.py
+++ b/src/notion.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 from typing import Any, Dict, List, Optional
 
 from .models.nutrition import NutritionEntry, StatusResponse
-from .services.notion import NotionClient
+from .services.interfaces import NotionAPI
 from .settings import Settings
 
 async def submit_to_notion(
-    entry: NutritionEntry, settings: Settings, client: NotionClient
+    entry: NutritionEntry, settings: Settings, client: NotionAPI
 ) -> StatusResponse:
     """Create a page in the configured Notion database for the entry."""
     payload: Dict[str, Any] = {
@@ -49,7 +49,7 @@ def parse_page(page: Dict[str, Any]) -> Optional[NutritionEntry]:
         return None
 
 async def query_entries(
-    filter_payload: Dict[str, Any], settings: Settings, client: NotionClient
+    filter_payload: Dict[str, Any], settings: Settings, client: NotionAPI
 ) -> List[NutritionEntry]:
     results: List[Dict[str, Any]] = await client.query(
         settings.notion_database_id, {"filter": filter_payload}
@@ -62,7 +62,7 @@ async def query_entries(
     return entries
 
 async def entries_on_date(
-    date: str, settings: Settings, client: NotionClient
+    date: str, settings: Settings, client: NotionAPI
 ) -> List[NutritionEntry]:
     return await query_entries(
         {"property": "Date", "date": {"equals": date}}, settings, client
@@ -72,7 +72,7 @@ async def entries_in_range(
     start_date: str,
     end_date: str,
     settings: Settings,
-    client: NotionClient,
+    client: NotionAPI,
 ) -> List[NutritionEntry]:
     return await query_entries(
         {

--- a/src/nutrition.py
+++ b/src/nutrition.py
@@ -5,12 +5,12 @@ from typing import Dict, List
 
 from .models.nutrition import DailyNutritionSummary, NutritionEntry
 from .notion import entries_in_range
-from .services.notion import NotionClient
+from .services.interfaces import NotionAPI
 from .settings import Settings
 
 
 async def get_daily_nutrition_summaries(
-    start_date: str, end_date: str, settings: Settings, client: NotionClient
+    start_date: str, end_date: str, settings: Settings, client: NotionAPI
 ) -> List[DailyNutritionSummary]:
     """Retrieve nutrition entries for a date range and aggregate by day."""
     entries: List[NutritionEntry] = await entries_in_range(

--- a/src/routes/nutrition.py
+++ b/src/routes/nutrition.py
@@ -14,7 +14,8 @@ from ..models.nutrition import (
 from ..models.time import get_local_time
 from ..notion import entries_on_date, submit_to_notion
 from ..nutrition import get_daily_nutrition_summaries
-from ..services.notion import NotionClient, get_notion_client
+from ..services.interfaces import NotionAPI
+from ..services.notion import get_notion_client
 from ..settings import Settings, get_settings
 from .utils import timezone_query
 
@@ -25,7 +26,7 @@ router: APIRouter = APIRouter()
 async def create_nutrition_entry(
     entry: NutritionEntry,
     settings: Settings = Depends(get_settings),
-    client: NotionClient = Depends(get_notion_client),
+    client: NotionAPI = Depends(get_notion_client),
 ) -> StatusResponse:
     return await submit_to_notion(entry, settings, client)
 
@@ -38,7 +39,7 @@ async def list_daily_nutrition_entries(
     date: str = Path(..., description="Date to fetch in YYYY-MM-DD format."),
     timezone: str = timezone_query,
     settings: Settings = Depends(get_settings),
-    client: NotionClient = Depends(get_notion_client),
+    client: NotionAPI = Depends(get_notion_client),
 ) -> NutritionEntriesResponse:
     entries: List[NutritionEntry] = await entries_on_date(date, settings, client)
     local_time, part = get_local_time(timezone)
@@ -58,7 +59,7 @@ async def list_nutrition_entries_by_period(
     ),
     timezone: str = timezone_query,
     settings: Settings = Depends(get_settings),
-    client: NotionClient = Depends(get_notion_client),
+    client: NotionAPI = Depends(get_notion_client),
 ) -> NutritionPeriodResponse:
     summaries: List[DailyNutritionSummary] = await get_daily_nutrition_summaries(
         start_date, end_date, settings, client

--- a/src/routes/workouts.py
+++ b/src/routes/workouts.py
@@ -9,7 +9,8 @@ from fastapi import APIRouter, Query, Depends
 from ..models.workout import ComplexAdvice, WorkoutLog
 from ..models.time import get_local_time
 from ..nutrition import get_daily_nutrition_summaries
-from ..services.notion import NotionClient, get_notion_client
+from ..services.interfaces import NotionAPI
+from ..services.notion import get_notion_client
 from ..services.redis import RedisClient, get_redis
 from ..settings import Settings, get_settings
 from ..withings import get_measurements
@@ -26,7 +27,7 @@ router: APIRouter = APIRouter()
 async def list_logged_workouts(
     days: int = Query(7, description="Number of days of logged workouts to retrieve."),
     settings: Settings = Depends(get_settings),
-    client: NotionClient = Depends(get_notion_client),
+    client: NotionAPI = Depends(get_notion_client),
 ) -> List[WorkoutLog]:
     return await fetch_workouts_from_notion(days, settings, client)
 
@@ -37,7 +38,7 @@ async def get_complex_advice(
     timezone: str = timezone_query,
     redis: RedisClient = Depends(get_redis),
     settings: Settings = Depends(get_settings),
-    client: NotionClient = Depends(get_notion_client),
+    client: NotionAPI = Depends(get_notion_client),
 ) -> ComplexAdvice:
     end: date = date.today()
     start: date = end - timedelta(days=days - 1)

--- a/src/services/interfaces.py
+++ b/src/services/interfaces.py
@@ -1,0 +1,47 @@
+"""Protocol interfaces for external service clients."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Protocol, runtime_checkable
+
+import httpx
+
+
+@runtime_checkable
+class NotionAPI(Protocol):
+    """Minimal interface for Notion API clients."""
+
+    async def query(
+        self, database_id: str, payload: Dict[str, Any]
+    ) -> List[Dict[str, Any]]:
+        """Query a database and return raw results."""
+
+    async def create(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        """Create a new page and return the created object."""
+
+    async def update(self, page_id: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+        """Update an existing page and return the updated object."""
+
+
+@runtime_checkable
+class StravaAPI(Protocol):
+    """HTTP client interface used for Strava requests."""
+
+    async def get(self, url: str, *, headers: Dict[str, str]) -> httpx.Response:  # pragma: no cover - thin wrapper
+        """Perform a GET request."""
+
+
+@runtime_checkable
+class WithingsAPI(Protocol):
+    """HTTP client interface used for Withings requests."""
+
+    async def get(
+        self, url: str, *, headers: Dict[str, str], params: Dict[str, Any]
+    ) -> httpx.Response:  # pragma: no cover - thin wrapper
+        """Perform a GET request."""
+
+    async def post(
+        self, url: str, *, data: Dict[str, Any]
+    ) -> httpx.Response:  # pragma: no cover - thin wrapper
+        """Perform a POST request."""
+

--- a/src/services/notion.py
+++ b/src/services/notion.py
@@ -6,9 +6,10 @@ import httpx
 from fastapi import Depends, HTTPException
 
 from ..settings import Settings, get_settings
+from .interfaces import NotionAPI
 
 
-class NotionClient:
+class NotionClient(NotionAPI):
     """Minimal Notion HTTP client with shared error handling."""
 
     def __init__(self, *, settings: Settings) -> None:
@@ -43,8 +44,7 @@ class NotionClient:
         resp = await self._request("PATCH", f"/pages/{page_id}", json=payload)
         return resp.json()
 
-
-def get_notion_client(settings: Settings = Depends(get_settings)) -> NotionClient:
-    """Dependency that provides a configured :class:`NotionClient` instance."""
+def get_notion_client(settings: Settings = Depends(get_settings)) -> NotionAPI:
+    """Dependency that provides a configured Notion API client."""
 
     return NotionClient(settings=settings)

--- a/src/services/strava_activity.py
+++ b/src/services/strava_activity.py
@@ -9,7 +9,8 @@ import httpx
 from fastapi import Depends, HTTPException
 
 from .redis import RedisClient, get_redis
-from .notion import NotionClient, get_notion_client
+from .interfaces import NotionAPI
+from .notion import get_notion_client
 from ..settings import Settings, get_settings
 from ..strava import refresh_access_token
 from ..metrics import hr_drift_from_splits, vo2max_minutes
@@ -21,7 +22,7 @@ class StravaActivityService:
     def __init__(
         self,
         http_client: httpx.AsyncClient,
-        notion_client: NotionClient,
+        notion_client: NotionAPI,
         settings: Settings,
         redis: RedisClient,
     ) -> None:
@@ -113,7 +114,7 @@ class StravaActivityService:
 async def get_strava_activity_service(
     redis: RedisClient = Depends(get_redis),
     settings: Settings = Depends(get_settings),
-    notion_client: NotionClient = Depends(get_notion_client),
+    notion_client: NotionAPI = Depends(get_notion_client),
 ) -> AsyncIterator[StravaActivityService]:
     async with httpx.AsyncClient() as http_client:
         yield StravaActivityService(http_client, notion_client, settings, redis)

--- a/src/workout_notion.py
+++ b/src/workout_notion.py
@@ -4,12 +4,12 @@ from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional
 
 from .models.workout import WorkoutLog
-from .services.notion import NotionClient
+from .services.interfaces import NotionAPI
 from .settings import Settings
 
 
 async def fetch_latest_athlete_profile(
-    settings: Settings, client: NotionClient
+    settings: Settings, client: NotionAPI
 ) -> Dict[str, Any]:
     """Fetch the latest athlete profile entry from Notion."""
     payload = {
@@ -43,7 +43,7 @@ async def save_workout_to_notion(
     tss: Optional[float] = None,
     intensity_factor: Optional[float] = None,
     settings: Settings,
-    client: NotionClient,
+    client: NotionAPI,
 ) -> None:
     """Store a Strava activity detail in the workout database.
 
@@ -141,7 +141,7 @@ def _parse_workout_page(page: Dict[str, Any]) -> Optional[WorkoutLog]:
 
 
 async def fetch_workouts_from_notion(
-    days: int, settings: Settings, client: NotionClient
+    days: int, settings: Settings, client: NotionAPI
 ) -> List[WorkoutLog]:
     """Return workouts from the workout database for the last ``days`` days."""
     start = (datetime.utcnow() - timedelta(days=days)).date().isoformat()


### PR DESCRIPTION
## Summary
- add Protocol interfaces for Notion, Strava, and Withings clients
- refactor services and routes to depend on NotionAPI interface
- adjust Notion dependency provider to return interface implementation
- replace monkeypatched tests with protocol-based stubs for Notion and Strava clients

## Testing
- `ruff check --fix src tests`
- `ruff check src tests`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689dccb6b3188330a14e2fd3f0e80e53