### PR TITLE
Add daily nutrition summary to daily endpoint

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -559,7 +559,7 @@
           },
           "nutrition": {
             "items": {
-              "$ref": "#/components/schemas/DailyNutritionSummary"
+              "$ref": "#/components/schemas/DailyNutritionSummaryWithEntries"
             },
             "type": "array",
             "title": "Nutrition"
@@ -600,21 +600,55 @@
             "type": "string",
             "title": "Date"
           },
-          "calories": {
+          "daily_calories_sum": {
             "type": "integer",
-            "title": "Calories"
+            "title": "Daily Calories Sum"
           },
-          "protein_g": {
+          "daily_protein_g_sum": {
             "type": "number",
-            "title": "Protein G"
+            "title": "Daily Protein G Sum"
           },
-          "carbs_g": {
+          "daily_carbs_g_sum": {
             "type": "number",
-            "title": "Carbs G"
+            "title": "Daily Carbs G Sum"
           },
-          "fat_g": {
+          "daily_fat_g_sum": {
             "type": "number",
-            "title": "Fat G"
+            "title": "Daily Fat G Sum"
+          }
+        },
+        "type": "object",
+        "required": [
+          "date",
+          "daily_calories_sum",
+          "daily_protein_g_sum",
+          "daily_carbs_g_sum",
+          "daily_fat_g_sum"
+        ],
+        "title": "DailyNutritionSummary",
+        "description": "Aggregated nutrition information for a single day."
+      },
+      "DailyNutritionSummaryWithEntries": {
+        "properties": {
+          "date": {
+            "type": "string",
+            "title": "Date"
+          },
+          "daily_calories_sum": {
+            "type": "integer",
+            "title": "Daily Calories Sum"
+          },
+          "daily_protein_g_sum": {
+            "type": "number",
+            "title": "Daily Protein G Sum"
+          },
+          "daily_carbs_g_sum": {
+            "type": "number",
+            "title": "Daily Carbs G Sum"
+          },
+          "daily_fat_g_sum": {
+            "type": "number",
+            "title": "Daily Fat G Sum"
           },
           "entries": {
             "items": {
@@ -627,14 +661,14 @@
         "type": "object",
         "required": [
           "date",
-          "calories",
-          "protein_g",
-          "carbs_g",
-          "fat_g",
+          "daily_calories_sum",
+          "daily_protein_g_sum",
+          "daily_carbs_g_sum",
+          "daily_fat_g_sum",
           "entries"
         ],
-        "title": "DailyNutritionSummary",
-        "description": "Aggregated nutrition information for a single day."
+        "title": "DailyNutritionSummaryWithEntries",
+        "description": "Daily summary extended with the list of individual entries."
       },
       "HTTPValidationError": {
         "properties": {
@@ -673,13 +707,17 @@
             },
             "type": "array",
             "title": "Entries"
+          },
+          "summary": {
+            "$ref": "#/components/schemas/DailyNutritionSummary"
           }
         },
         "type": "object",
         "required": [
           "local_time",
           "part_of_day",
-          "entries"
+          "entries",
+          "summary"
         ],
         "title": "NutritionEntriesResponse",
         "description": "Response wrapper for a list of nutrition entries with timing context."
@@ -761,7 +799,7 @@
           },
           "nutrition": {
             "items": {
-              "$ref": "#/components/schemas/DailyNutritionSummary"
+              "$ref": "#/components/schemas/DailyNutritionSummaryWithEntries"
             },
             "type": "array",
             "title": "Nutrition"

--- a/src/main.py
+++ b/src/main.py
@@ -8,6 +8,7 @@ from fastapi.responses import JSONResponse
 from .routes.nutrition import router as nutrition_router
 from .routes.metrics import router as metrics_router
 from .routes.workouts import router as workouts_router
+from .routes.advice import router as advice_router
 from .routes.strava import router as strava_router
 from .security import verify_api_key
 from .strava_webhook import webhook_router
@@ -36,7 +37,13 @@ async def get_api_schema(request: Request, _: Any = Depends(verify_api_key)) -> 
     return JSONResponse(openapi_schema)
 
 
-for router in (nutrition_router, metrics_router, workouts_router, strava_router):
+for router in (
+    nutrition_router,
+    metrics_router,
+    workouts_router,
+    advice_router,
+    strava_router,
+):
     app.include_router(router, prefix="/v2", dependencies=[Depends(verify_api_key)])
 
 # Strava webhook endpoints (no API key security)

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -2,11 +2,13 @@ from .body import BodyMeasurement, BodyMeasurementAverages
 from .nutrition import (
     NutritionEntry,
     DailyNutritionSummary,
+    DailyNutritionSummaryWithEntries,
     StatusResponse,
     NutritionEntriesResponse,
     NutritionPeriodResponse,
 )
-from .workout import Workout, WorkoutLog, StravaEvent, AthleteMetrics, ComplexAdvice
+from .workout import Workout, WorkoutLog, StravaEvent
+from .advice import AthleteMetrics, ComplexAdvice
 from .time import TimeContext
 from .strava import StravaActivity, MetricResults, Split, Lap
 
@@ -15,6 +17,7 @@ __all__ = [
     'BodyMeasurementAverages',
     'NutritionEntry',
     'DailyNutritionSummary',
+    'DailyNutritionSummaryWithEntries',
     'StatusResponse',
     'NutritionEntriesResponse',
     'NutritionPeriodResponse',

--- a/src/models/advice.py
+++ b/src/models/advice.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from typing import List
+
+from pydantic import BaseModel
+
+from .time import TimeContext
+from .body import BodyMeasurement
+from .nutrition import DailyNutritionSummaryWithEntries
+from .workout import WorkoutLog
+
+
+class AthleteMetrics(BaseModel):
+    """Latest athlete-level metrics such as FTP and max heart rate."""
+
+    ftp: float | None = None
+    weight: float | None = None
+    max_hr: float | None = None
+
+
+class ComplexAdvice(TimeContext):
+    """Combined nutrition, body metrics, workout data, and athlete metrics."""
+
+    nutrition: List[DailyNutritionSummaryWithEntries]
+    metrics: List[BodyMeasurement]
+    workouts: List[WorkoutLog]
+    athlete_metrics: AthleteMetrics

--- a/src/models/nutrition.py
+++ b/src/models/nutrition.py
@@ -30,10 +30,15 @@ class DailyNutritionSummary(BaseModel):
     """Aggregated nutrition information for a single day."""
 
     date: str
-    calories: int
-    protein_g: float
-    carbs_g: float
-    fat_g: float
+    daily_calories_sum: int
+    daily_protein_g_sum: float
+    daily_carbs_g_sum: float
+    daily_fat_g_sum: float
+
+
+class DailyNutritionSummaryWithEntries(DailyNutritionSummary):
+    """Daily summary extended with the list of individual entries."""
+
     entries: List[NutritionEntry]
 
 
@@ -41,9 +46,10 @@ class NutritionEntriesResponse(TimeContext):
     """Response wrapper for a list of nutrition entries with timing context."""
 
     entries: List[NutritionEntry]
+    summary: DailyNutritionSummary
 
 
 class NutritionPeriodResponse(TimeContext):
     """Response wrapper for a range of daily nutrition summaries with timing context."""
 
-    nutrition: List[DailyNutritionSummary]
+    nutrition: List[DailyNutritionSummaryWithEntries]

--- a/src/models/workout.py
+++ b/src/models/workout.py
@@ -1,14 +1,9 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Optional, Dict, Any, List
+from typing import Optional, Dict, Any
 
 from pydantic import BaseModel, Field
-
-from .time import TimeContext
-
-from .body import BodyMeasurement
-from .nutrition import DailyNutritionSummary
 
 
 class Workout(BaseModel):
@@ -101,20 +96,3 @@ class WorkoutLog(BaseModel):
     tss: Optional[float] = None
     intensity_factor: Optional[float] = None
     notes: Optional[str] = None
-
-
-class AthleteMetrics(BaseModel):
-    """Latest athlete-level metrics such as FTP and max heart rate."""
-
-    ftp: Optional[float] = None
-    weight: Optional[float] = None
-    max_hr: Optional[float] = None
-
-
-class ComplexAdvice(TimeContext):
-    """Combined nutrition, body metrics, workout data, and athlete metrics."""
-
-    nutrition: List[DailyNutritionSummary]
-    metrics: List[BodyMeasurement]
-    workouts: List[WorkoutLog]
-    athlete_metrics: AthleteMetrics

--- a/src/routes/advice.py
+++ b/src/routes/advice.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import date, timedelta
+
+from fastapi import APIRouter, Depends, Query
+
+from ..models.advice import ComplexAdvice
+from ..models.time import get_local_time
+from ..nutrition import get_daily_nutrition_summaries
+from ..services.interfaces import NotionAPI
+from ..services.notion import get_notion_client
+from ..services.redis import RedisClient, get_redis
+from ..settings import Settings, get_settings
+from ..withings import get_measurements
+from ..workout_notion import (
+    fetch_latest_athlete_profile,
+    fetch_workouts_from_notion,
+)
+from .utils import timezone_query
+
+router: APIRouter = APIRouter()
+
+
+@router.get("/complex-advice", response_model=ComplexAdvice)
+async def get_complex_advice(
+    days: int = Query(7, description="Number of days of data to retrieve."),
+    timezone: str = timezone_query,
+    redis: RedisClient = Depends(get_redis),
+    settings: Settings = Depends(get_settings),
+    client: NotionAPI = Depends(get_notion_client),
+) -> ComplexAdvice:
+    end: date = date.today()
+    start: date = end - timedelta(days=days - 1)
+    nutrition_coro = get_daily_nutrition_summaries(
+        start.isoformat(), end.isoformat(), settings, client
+    )
+    metrics_coro = get_measurements(days, redis, settings)
+    workouts_coro = fetch_workouts_from_notion(days, settings, client)
+    athlete_coro = fetch_latest_athlete_profile(settings, client)
+    nutrition, metrics, workouts, athlete_metrics = await asyncio.gather(
+        nutrition_coro, metrics_coro, workouts_coro, athlete_coro
+    )
+    local_time, part = get_local_time(timezone)
+    return ComplexAdvice(
+        nutrition=nutrition,
+        metrics=metrics,
+        workouts=workouts,
+        athlete_metrics=athlete_metrics,
+        local_time=local_time,
+        part_of_day=part,
+    )

--- a/src/routes/workouts.py
+++ b/src/routes/workouts.py
@@ -1,24 +1,14 @@
 from __future__ import annotations
 
 from typing import List
-from datetime import date, timedelta
-import asyncio
 
 from fastapi import APIRouter, Query, Depends
 
-from ..models.workout import ComplexAdvice, WorkoutLog
-from ..models.time import get_local_time
-from ..nutrition import get_daily_nutrition_summaries
+from ..models.workout import WorkoutLog
 from ..services.interfaces import NotionAPI
 from ..services.notion import get_notion_client
-from ..services.redis import RedisClient, get_redis
 from ..settings import Settings, get_settings
-from ..withings import get_measurements
-from ..workout_notion import (
-    fetch_latest_athlete_profile,
-    fetch_workouts_from_notion,
-)
-from .utils import timezone_query
+from ..workout_notion import fetch_workouts_from_notion
 
 router: APIRouter = APIRouter()
 
@@ -32,31 +22,3 @@ async def list_logged_workouts(
     return await fetch_workouts_from_notion(days, settings, client)
 
 
-@router.get("/complex-advice", response_model=ComplexAdvice)
-async def get_complex_advice(
-    days: int = Query(7, description="Number of days of data to retrieve."),
-    timezone: str = timezone_query,
-    redis: RedisClient = Depends(get_redis),
-    settings: Settings = Depends(get_settings),
-    client: NotionAPI = Depends(get_notion_client),
-) -> ComplexAdvice:
-    end: date = date.today()
-    start: date = end - timedelta(days=days - 1)
-    nutrition_coro = get_daily_nutrition_summaries(
-        start.isoformat(), end.isoformat(), settings, client
-    )
-    metrics_coro = get_measurements(days, redis, settings)
-    workouts_coro = fetch_workouts_from_notion(days, settings, client)
-    athlete_coro = fetch_latest_athlete_profile(settings, client)
-    nutrition, metrics, workouts, athlete_metrics = await asyncio.gather(
-        nutrition_coro, metrics_coro, workouts_coro, athlete_coro
-    )
-    local_time, part = get_local_time(timezone)
-    return ComplexAdvice(
-        nutrition=nutrition,
-        metrics=metrics,
-        workouts=workouts,
-        athlete_metrics=athlete_metrics,
-        local_time=local_time,
-        part_of_day=part,
-    )


### PR DESCRIPTION
## Summary
- define a `DailyNutritionSummary` without entries and separate `DailyNutritionSummaryWithEntries` for period results
- aggregate entries with an `include_entries` flag to avoid duplicating entry data in the daily response
- ensure tests check that `/nutrition-entries/daily/{date}` omits embedded entries and regenerate the OpenAPI schema
- move `complex-advice` into dedicated router and models, ensuring nutrition entries remain in its response

## Testing
- `ruff check --fix src tests`
- `ruff check src tests`
- `python generate_openapi.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689dd0c98ed88330bad6b7eb474b2f7b