### PR TITLE
Add missing Strava activity identifiers

### DIFF
--- a/src/models/strava.py
+++ b/src/models/strava.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import List, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class Split(BaseModel):
@@ -17,9 +17,24 @@ class Lap(Split):
 
 
 class StravaActivity(BaseModel):
-    splits_metric: List[Split] = []
-    laps: List[Lap] = []
+    """Subset of fields returned by the Strava activity detail endpoint."""
+
+    id: int
+    name: str
+    start_date: Optional[str] = None
+    elapsed_time: Optional[int] = None
+    distance: Optional[float] = None
+    total_elevation_gain: Optional[float] = None
+    type: Optional[str] = None
+    splits_metric: List[Split] = Field(default_factory=list)
+    laps: List[Lap] = Field(default_factory=list)
+    average_cadence: Optional[float] = None
+    average_watts: Optional[float] = None
     weighted_average_watts: Optional[float] = None
+    kilojoules: Optional[float] = None
+    calories: Optional[float] = None
+    average_heartrate: Optional[float] = None
+    max_heartrate: Optional[float] = None
     moving_time: Optional[int] = None
     description: Optional[str] = None
 

--- a/src/workout_notion.py
+++ b/src/workout_notion.py
@@ -57,13 +57,13 @@ async def save_workout_to_notion(
     day_of_week = datetime.fromisoformat(date_only).strftime("%A")
 
     props: Dict[str, Any] = {
-        "Name": {"title": [{"text": {"content": detail.get("name", "")}}]},
+        "Name": {"title": [{"text": {"content": detail["name"]}}]},
         "Date": {"date": {"start": date_only}},
         "Duration [s]": {"number": detail.get("elapsed_time")},
         "Distance [m]": {"number": detail.get("distance")},
         "Elevation [m]": {"number": detail.get("total_elevation_gain")},
         "Type": {"rich_text": [{"text": {"content": str(detail.get("type", ""))}}]},
-        "Id": {"number": detail.get("id")},
+        "Id": {"number": detail["id"]},
         "Day of week": {"select": {"name": day_of_week}},
     }
 
@@ -85,7 +85,7 @@ async def save_workout_to_notion(
 
     # Attempt to find an existing page with the same activity id and update it
     query_payload = {
-        "filter": {"property": "Id", "number": {"equals": detail.get("id")}},
+        "filter": {"property": "Id", "number": {"equals": detail["id"]}},
         "page_size": 1,
     }
     resp = await client.query(settings.notion_workout_database_id, query_payload)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -466,6 +466,8 @@ async def test_process_activity_uses_laps_and_computes_metrics() -> None:
     class FakeStravaClient:
         async def get(self, url: str, *, headers: Dict[str, str]) -> httpx.Response:  # type: ignore[override]
             data = {
+                "id": 1,
+                "name": "Ride",
                 "splits_metric": [
                     {"average_heartrate": 100, "moving_time": 60},
                     {"average_heartrate": 100, "moving_time": 60},


### PR DESCRIPTION
## Summary
- require `id` and `name` on `StravaActivity` to guarantee valid Notion queries
- use those identifiers directly when persisting to Notion to avoid null filters

## Testing
- `ruff check --fix src tests`
- `ruff check src tests`
- `pytest -q`
- `python generate_openapi.py`


------
https://chatgpt.com/codex/tasks/task_e_689edb6430988330a685a0f474d04427