### PR TITLE
Mark OpenAPI operations as non-consequential

### DIFF
--- a/generate_openapi.py
+++ b/generate_openapi.py
@@ -12,6 +12,13 @@ def generate_openapi() -> None:
     schema["servers"] = [
         {"url": "https://notionuploader-groa.onrender.com"}
     ]
+
+    # Mark all operations as non-consequential so they can be always allowed
+    for path_item in schema.get("paths", {}).values():
+        for operation in path_item.values():
+            if isinstance(operation, dict):
+                operation["x-openai-isConsequential"] = False
+                operation["is_consequential"] = False
     output_path = Path(__file__).resolve().parent / "openapi.json"
     output_path.write_text(json.dumps(schema, indent=2))
 

--- a/openapi.json
+++ b/openapi.json
@@ -25,7 +25,9 @@
           {
             "ApiKeyAuth": []
           }
-        ]
+        ],
+        "x-openai-isConsequential": false,
+        "is_consequential": false
       }
     },
     "/v2/nutrition-entries": {
@@ -68,7 +70,9 @@
           {
             "ApiKeyAuth": []
           }
-        ]
+        ],
+        "x-openai-isConsequential": false,
+        "is_consequential": false
       }
     },
     "/v2/nutrition-entries/daily/{date}": {
@@ -126,7 +130,9 @@
               }
             }
           }
-        }
+        },
+        "x-openai-isConsequential": false,
+        "is_consequential": false
       }
     },
     "/v2/nutrition-entries/period": {
@@ -195,7 +201,9 @@
               }
             }
           }
-        }
+        },
+        "x-openai-isConsequential": false,
+        "is_consequential": false
       }
     },
     "/v2/body-measurements": {
@@ -247,7 +255,9 @@
               }
             }
           }
-        }
+        },
+        "x-openai-isConsequential": false,
+        "is_consequential": false
       }
     },
     "/v2/workout-logs": {
@@ -298,7 +308,9 @@
               }
             }
           }
-        }
+        },
+        "x-openai-isConsequential": false,
+        "is_consequential": false
       }
     },
     "/v2/complex-advice": {
@@ -357,7 +369,9 @@
               }
             }
           }
-        }
+        },
+        "x-openai-isConsequential": false,
+        "is_consequential": false
       }
     }
   },


### PR DESCRIPTION
## Summary
- flag all OpenAPI operations with `x-openai-isConsequential` and `is_consequential` set to `false`
- regenerate `openapi.json` with the new operation flags

## Testing
- `ruff check --fix src tests`
- `ruff check src tests`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a066ec21b48330b34997ed72c68033