### PR TITLE
feat: add during-workout meal type

### DIFF
--- a/bruno/Nutrition Logger/Log a food entry to Notion.bru
+++ b/bruno/Nutrition Logger/Log a food entry to Notion.bru
@@ -22,7 +22,7 @@ body:json {
     "protein_g": 1.7,
     "carbs_g": 20.8,
     "fat_g": 10.8,
-    "meal_type": "Snack",
+    "meal_type": "During-workout",
     "notes": "70g serving, mango flavor"
   }
 }

--- a/openapi.json
+++ b/openapi.json
@@ -862,6 +862,7 @@
               "Dinner",
               "Snack",
               "Pre-workout",
+              "During-workout",
               "Post-workout"
             ],
             "title": "Meal Type"

--- a/src/models/nutrition.py
+++ b/src/models/nutrition.py
@@ -15,7 +15,13 @@ class NutritionEntry(BaseModel):
     carbs_g: float
     fat_g: float
     meal_type: Literal[
-        "Breakfast", "Lunch", "Dinner", "Snack", "Pre-workout", "Post-workout"
+        "Breakfast",
+        "Lunch",
+        "Dinner",
+        "Snack",
+        "Pre-workout",
+        "During-workout",
+        "Post-workout",
     ]
     notes: str = Field(..., min_length=1)
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -96,7 +96,7 @@ async def test_log_nutrition_success(respx_mock: respx.MockRouter) -> None:
         "protein_g": 0.5,
         "carbs_g": 25,
         "fat_g": 0.3,
-        "meal_type": "Snack",
+        "meal_type": "During-workout",
         "notes": "Fresh",
     }
     transport: httpx.ASGITransport = httpx.ASGITransport(app=app)
@@ -129,7 +129,7 @@ async def test_log_nutrition_error(respx_mock: respx.MockRouter) -> None:
         "protein_g": 0.5,
         "carbs_g": 25,
         "fat_g": 0.3,
-        "meal_type": "Snack",
+        "meal_type": "During-workout",
         "notes": "Fresh",
     }
     transport: httpx.ASGITransport = httpx.ASGITransport(app=app)


### PR DESCRIPTION
## Summary
- allow logging foods consumed during a workout via new `During-workout` meal type
- document new meal type in API example and OpenAPI schema
- test nutrition logging with the new meal type

## Testing
- `ruff check --fix src tests`
- `ruff check src tests`
- `python generate_openapi.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b423301a048330b934ef48352223f4