### PR TITLE
Handle missing heart-rate data gracefully

### DIFF
--- a/tests/test_vo2max.py
+++ b/tests/test_vo2max.py
@@ -121,3 +121,16 @@ def test_vo2max_invalid_splits():
     # Should handle invalid data gracefully
     result = vo2max_minutes(splits, max_hr)
     assert result == 0.0
+
+
+def test_vo2max_missing_heart_rate_data():
+    """Splits without heart-rate data should produce zero VO2 time."""
+    max_hr = 190
+    splits = [
+        {"moving_time": 60, "average_heartrate": None, "max_heartrate": 180},
+        {"moving_time": 60, "average_heartrate": 175, "max_heartrate": None},
+    ]
+
+    result = vo2max_minutes(splits, max_hr)
+
+    assert result == 0.0


### PR DESCRIPTION
## Summary
- guard the heart-rate drift calculation against missing split data and avoid VO2 computations without valid inputs
- extend the metrics and Strava service tests to cover workouts that lack heart-rate information
- ensure VO2 calculations return zero when splits only contain empty heart-rate values

## Testing
- ruff check --fix src tests
- ruff check src tests
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68c8591af58c8330b1ef72da7d71629f