### PR TITLE
Use platform imports for configuration and clients

### DIFF
--- a/src/notion/infrastructure/nutrition_repository.py
+++ b/src/notion/infrastructure/nutrition_repository.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
+from platform.config import Settings
 from typing import Any, Dict, List, Optional
 
 from ...models.nutrition import NutritionEntry
 from ...services.interfaces import NotionAPI
-from ...settings import Settings
 from ..application.ports import NutritionRepository
 
 

--- a/src/notion/infrastructure/workout_repository.py
+++ b/src/notion/infrastructure/workout_repository.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
+from platform.config import Settings
 from typing import Any, Dict, List, Optional
 
 from ...domain.body_metrics.hr import estimate_if_tss_from_hr
 from ...models.workout import WorkoutLog
 from ...services.interfaces import NotionAPI
-from ...settings import Settings
 from ..application.ports import WorkoutRepository
 
 

--- a/src/platform/wiring.py
+++ b/src/platform/wiring.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from platform.clients import RedisClient, get_redis
+from platform.config import Settings, get_settings
 from typing import AsyncIterator
 
 import httpx
@@ -24,8 +26,6 @@ from ..notion.infrastructure.nutrition_repository import create_notion_nutrition
 from ..notion.infrastructure.workout_repository import create_notion_workout_adapter
 from ..services.interfaces import NotionAPI
 from ..services.notion import get_notion_client
-from ..services.redis import RedisClient, get_redis
-from ..settings import Settings, get_settings
 from ..strava.application import StravaActivityCoordinator
 from ..strava.infrastructure.client import create_strava_client_adapter
 from ..withings.application import WithingsMeasurementsPort

--- a/src/services/notion.py
+++ b/src/services/notion.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
+from platform.config import Settings, get_settings
 from typing import Any, Dict
 
 import httpx
 from fastapi import Depends, HTTPException
 
-from ..settings import Settings, get_settings
 from .interfaces import NotionAPI
 
 

--- a/src/strava/infrastructure/client.py
+++ b/src/strava/infrastructure/client.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
+from platform.clients import RedisClient
+from platform.config import Settings
 from typing import Any, Optional
 
 import httpx
 
-from ...services.redis import RedisClient
-from ...settings import Settings
 from ..application.ports import StravaAuthError, StravaClientPort
 
 

--- a/src/withings/infrastructure/client.py
+++ b/src/withings/infrastructure/client.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 
 import time
 from datetime import datetime
+from platform.clients import RedisClient
+from platform.config import Settings
 from typing import List, Sequence
 
 import httpx
 
 from ...models.body import BodyMeasurement
-from ...services.redis import RedisClient
-from ...settings import Settings
 from ..application.ports import WithingsMeasurementsPort
 
 

--- a/tests/api/helpers.py
+++ b/tests/api/helpers.py
@@ -7,7 +7,7 @@ import hmac
 import json
 from typing import Any, Dict
 
-from src.settings import Settings
+from platform.config import Settings
 
 _SENTINEL = object()
 

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import httpx
 import pytest
 
-from src.settings import Settings
+from platform.config import Settings
 
 pytestmark = pytest.mark.asyncio
 

--- a/tests/api/test_nutrition.py
+++ b/tests/api/test_nutrition.py
@@ -8,7 +8,7 @@ import httpx
 import pytest
 from fastapi import HTTPException
 
-from src.settings import Settings
+from platform.config import Settings
 from tests.api.helpers import (
     assert_nutrition_entry,
     build_nutrition_create_payload,

--- a/tests/api/test_strava_webhook.py
+++ b/tests/api/test_strava_webhook.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import httpx
 import pytest
 
-from src.settings import Settings
+from platform.config import Settings
 from tests.api.helpers import encode_signed_strava_event, make_strava_event
 from tests.conftest import StravaCoordinatorSpy
 

--- a/tests/api/test_workouts.py
+++ b/tests/api/test_workouts.py
@@ -9,7 +9,7 @@ from fastapi import FastAPI
 
 from src.application.workouts import WorkoutNotFoundError
 from src.platform.wiring import get_sync_workout_metrics_use_case
-from src.settings import Settings
+from platform.config import Settings
 from tests.conftest import NotionAPIStub
 
 pytestmark = pytest.mark.asyncio

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,8 +19,8 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from src import main
 from src.services.interfaces import NotionAPI
 from src.services.notion import get_notion_client
-from src.services.redis import RedisClient, get_redis
-from src.settings import Settings, get_settings
+from platform.clients import RedisClient, get_redis
+from platform.config import Settings, get_settings
 from src.platform.wiring import (
     provide_strava_activity_coordinator,
     provide_withings_port,

--- a/tests/fakes/notion.py
+++ b/tests/fakes/notion.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, Dict, Iterable, List, Tuple
 
 from src.services.interfaces import NotionAPI
-from src.settings import Settings
+from platform.config import Settings
 
 
 class NotionWorkoutFake(NotionAPI):

--- a/tests/test_strava_client.py
+++ b/tests/test_strava_client.py
@@ -12,7 +12,7 @@ import pytest
 # Ensure repository root on path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from src.settings import Settings
+from platform.config import Settings
 from src.strava.application.ports import StravaAuthError
 from src.strava.infrastructure.client import StravaClientAdapter
 

--- a/tests/test_strava_coordinator.py
+++ b/tests/test_strava_coordinator.py
@@ -10,7 +10,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from src.models import MetricResults, StravaActivity
 from src.notion.application.ports import WorkoutRepository
-from src.settings import Settings
+from platform.config import Settings
 from src.strava import StravaActivityCoordinator
 from src.strava.domain.metrics import compute_activity_metrics
 from src.strava.infrastructure.client import StravaClientAdapter

--- a/tests/test_withings_client.py
+++ b/tests/test_withings_client.py
@@ -10,7 +10,7 @@ import respx
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from src.models.body import BodyMeasurement
-from src.settings import Settings
+from platform.config import Settings
 from src.withings.infrastructure.client import WithingsMeasurementsAdapter
 
 

--- a/tests/test_workout_notion.py
+++ b/tests/test_workout_notion.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 
 from src.notion.infrastructure.workout_repository import NotionWorkoutAdapter
-from src.settings import Settings
+from platform.config import Settings
 
 from tests.builders import (
     make_notion_profile,


### PR DESCRIPTION
## Summary
- replace remaining src.settings and src.services.redis imports with platform.config and platform.clients
- update service and adapter modules to type against the platform-provided Settings and RedisClient definitions
- align pytest fixtures and helpers with the new platform entry points

## Testing
- `uv run ruff check --fix src tests`
- `uv run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_690aeaf01b0c83309beefd2001fa27a4