### PR TITLE
Update README references for platform modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ FastAPI service that syncs nutrition, workout, and biometric data from external 
 
 ## Architecture at a Glance
 - **API surface**: `src/routes/` defines versioned FastAPI routers (nutrition, metrics, workouts, advice, Strava) secured by an API key middleware and exposed through `src/main.py`.
-- **Integrations**: Provider-specific clients live in `src/services/` and `src/withings.py` / `src/strava.py`. Shared helpers reside in `src/domain/` and `src/notion/`.
-- **Configuration**: `src/platform/config.py` centralizes environment variables with Pydantic settings and supports Render's uppercase environment naming.
+- **Integrations**: Provider-specific clients live in `src/services/` and `src/withings.py` / `src/strava.py`. Shared helpers reside in `src/domain/` (including `src/domain/body_metrics/`) and `src/notion/`.
+- **Configuration**: `platform.config` centralizes environment variables with Pydantic settings and supports Render's uppercase environment naming, while security-critical utilities (API key validation, hashing) live in `platform.security`.
 - **Schemas**: `openapi.json` is generated from the running app via `uv run python generate_openapi.py` when routes or models change.
 
 ## Prerequisites
@@ -43,7 +43,7 @@ Define the following variables (case insensitive thanks to `SettingsConfigDict(c
 
 | Variable | Description |
 | --- | --- |
-| `API_KEY` | Shared secret for API-key auth enforced by `src/platform/security.py`. |
+| `API_KEY` | Shared secret for API-key auth enforced by `platform.security`. |
 | `NOTION_SECRET` | Notion integration secret used by Notion client wrappers. |
 | `NOTION_DATABASE_ID` | Target Notion database for nutrition entries. |
 | `NOTION_WORKOUT_DATABASE_ID` | Notion database receiving workout logs. |


### PR DESCRIPTION
## Summary
- update the architecture overview to highlight platform.config, platform.security, and the body metrics domain helpers
- refresh the configuration reference to point to the new security module

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_690aedd16c78833081a7625d4af6f8be