### PR TITLE
Health check: record and return previous probe timestamp in Redis; update docs and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ uv sync --dev
 uv run uvicorn src.main:app --reload
 ```
 
-With the server running, `/` and `/healthz` provide lightweight health checks, while the authenticated API lives under `/v2`. Regenerate the OpenAPI description after changing models or routes:
+With the server running, `/` and `/healthz` provide lightweight health checks that return the prior Redis-recorded probe timestamp and store the current probe timestamp, while the authenticated API lives under `/v2`. Regenerate the OpenAPI description after changing models or routes:
 
 ```bash
 uv run python generate_openapi.py
@@ -72,7 +72,7 @@ Run the import boundary checks, linter, and coverage-enabled tests before every 
 - **Review the README**: Treat this document as the source of truth for setup and deployment. Re-read it after each change and update any sections impacted by your modifications before merging.
 
 ## Deployment Notes
-- Render deploys this service via webhook; health checks hit `/healthz`, which now also verifies Upstash Redis connectivity on each probe.
+- Render deploys this service via webhook; health checks hit `/healthz`, which reads the previous Redis-recorded probe timestamp and upserts the current timestamp on each probe.
 - The production OpenAPI schema is exposed at `/v2/api-schema` with the server URL pre-set to Render (`https://notionuploader-groa.onrender.com`).
 - Ensure any schema or dependency changes are committed together so the Render build installs the correct versions from `uv.lock`.
 

--- a/src/main.py
+++ b/src/main.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from platform import verify_api_key
 from platform.clients import RedisClient, get_redis
 from typing import Any, Dict
@@ -14,6 +15,9 @@ from .routes.nutrition import router as nutrition_router
 from .routes.strava import router as strava_router
 from .routes.workouts import router as workouts_router
 from .strava_webhook import webhook_router
+
+HEALTHZ_LAST_CHECK_KEY = "healthz:last_check_at"
+
 
 app: FastAPI = FastAPI(
     title="Nutrition Logger",
@@ -41,10 +45,12 @@ async def handle_httpx_connect_error(_: Request, exc: httpx.ConnectError) -> JSO
 
 @app.api_route("/", methods=["GET", "HEAD"], include_in_schema=False)
 @app.api_route("/healthz", methods=["GET", "HEAD"], include_in_schema=False)
-async def healthz(redis: RedisClient = Depends(get_redis)) -> dict[str, str]:
-    """Health check endpoint that verifies API process and Upstash Redis connectivity."""
-    redis.get("healthz:upstash")
-    return {"status": "ok"}
+async def healthz(redis: RedisClient = Depends(get_redis)) -> dict[str, str | None]:
+    """Record and return the previous health check timestamp."""
+    previous_check_at = redis.get(HEALTHZ_LAST_CHECK_KEY)
+    checked_at = datetime.now(timezone.utc).isoformat()
+    redis.set(HEALTHZ_LAST_CHECK_KEY, checked_at)
+    return {"status": "ok", "previous_check_at": previous_check_at}
 
 
 @app.get("/v2/api-schema")

--- a/tests/test_healthz.py
+++ b/tests/test_healthz.py
@@ -1,8 +1,12 @@
+from datetime import datetime, timezone
+
 import httpx
 import pytest
 from fastapi import FastAPI
 
 from platform.clients import get_redis
+from src.main import HEALTHZ_LAST_CHECK_KEY
+from tests.conftest import RedisFake
 
 
 pytestmark = pytest.mark.asyncio
@@ -12,7 +16,7 @@ class BrokenRedis:
     def get(self, key: str):  # noqa: ANN001, ANN201
         raise httpx.ConnectError(
             "upstash unavailable",
-            request=httpx.Request("GET", "https://redis.example.com/get/healthz:upstash"),
+            request=httpx.Request("GET", "https://redis.example.com/get/healthz:last_check_at"),
         )
 
     def set(self, key: str, value: str, ex: int | None = None) -> None:  # noqa: ARG002
@@ -29,6 +33,46 @@ async def test_head_healthz(client: httpx.AsyncClient) -> None:
     response = await client.head("/healthz")
     assert response.status_code == 200
     assert response.text == ""
+
+
+async def test_healthz_returns_previous_check_and_records_current_timestamp(
+    client: httpx.AsyncClient, redis_fake: RedisFake
+) -> None:
+    previous_check_at = "2026-05-10T12:00:00+00:00"
+    redis_fake.expect_get(HEALTHZ_LAST_CHECK_KEY, returns=previous_check_at)
+    redis_fake.expect_set(HEALTHZ_LAST_CHECK_KEY)
+
+    response = await client.get("/healthz")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "status": "ok",
+        "previous_check_at": previous_check_at,
+    }
+    redis_fake.assert_last_get(HEALTHZ_LAST_CHECK_KEY)
+    recorded_check_at = redis_fake.store[HEALTHZ_LAST_CHECK_KEY]
+    assert datetime.fromisoformat(recorded_check_at).tzinfo == timezone.utc
+    assert recorded_check_at != previous_check_at
+
+
+async def test_root_returns_previous_check_and_records_current_timestamp(
+    client: httpx.AsyncClient, redis_fake: RedisFake
+) -> None:
+    previous_check_at = "2026-05-10T12:00:00+00:00"
+    redis_fake.expect_get(HEALTHZ_LAST_CHECK_KEY, returns=previous_check_at)
+    redis_fake.expect_set(HEALTHZ_LAST_CHECK_KEY)
+
+    response = await client.get("/")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "status": "ok",
+        "previous_check_at": previous_check_at,
+    }
+    redis_fake.assert_last_get(HEALTHZ_LAST_CHECK_KEY)
+    recorded_check_at = redis_fake.store[HEALTHZ_LAST_CHECK_KEY]
+    assert datetime.fromisoformat(recorded_check_at).tzinfo == timezone.utc
+    assert recorded_check_at != previous_check_at
 
 
 async def test_healthz_returns_503_when_upstash_is_unreachable(

--- a/tests/test_import_linter_runner.py
+++ b/tests/test_import_linter_runner.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import click
+import pytest
+
+from src import import_linter_runner
+
+
+def test_main_invokes_import_linter(monkeypatch: pytest.MonkeyPatch) -> None:
+    recorded: dict[str, object] = {}
+
+    def fake_main(**kwargs: object) -> None:
+        recorded.update(kwargs)
+
+    monkeypatch.setattr(import_linter_runner.lint_imports_command, "main", fake_main)
+
+    assert import_linter_runner.main(["--verbose"]) == 0
+    assert recorded == {
+        "args": ["--verbose"],
+        "prog_name": "import-linter",
+        "standalone_mode": False,
+    }
+
+
+def test_main_returns_click_exit_code(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_main(**_: object) -> None:
+        raise click.exceptions.Exit(2)
+
+    monkeypatch.setattr(import_linter_runner.lint_imports_command, "main", fake_main)
+
+    assert import_linter_runner.main([]) == 2
+
+
+def test_main_shows_click_exception(monkeypatch: pytest.MonkeyPatch) -> None:
+    shown: list[bool] = []
+
+    class FakeClickException(click.ClickException):
+        def show(self, file: object | None = None) -> None:
+            shown.append(True)
+
+    def fake_main(**_: object) -> None:
+        raise FakeClickException("broken")
+
+    monkeypatch.setattr(import_linter_runner.lint_imports_command, "main", fake_main)
+
+    assert import_linter_runner.main([]) == 1
+    assert shown == [True]

--- a/tests/test_notion_client.py
+++ b/tests/test_notion_client.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+from fastapi import HTTPException
+
+from src.services.notion import NotionClient, get_notion_client
+from platform.config import Settings
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_notion_client_query_create_update_and_retrieve(
+    respx_mock: respx.Router, settings: Settings
+) -> None:
+    respx_mock.post("https://api.notion.com/v1/databases/db/query").mock(
+        return_value=httpx.Response(200, json={"object": "list"})
+    )
+    respx_mock.post("https://api.notion.com/v1/pages").mock(
+        return_value=httpx.Response(200, json={"id": "created"})
+    )
+    respx_mock.patch("https://api.notion.com/v1/pages/page-id").mock(
+        return_value=httpx.Response(200, json={"id": "updated"})
+    )
+    respx_mock.get("https://api.notion.com/v1/pages/page-id").mock(
+        return_value=httpx.Response(200, json={"id": "retrieved"})
+    )
+
+    client = NotionClient(settings=settings)
+
+    assert await client.query("db", {"filter": {}}) == {"object": "list"}
+    assert await client.create({"properties": {}}) == {"id": "created"}
+    assert await client.update("page-id", {"properties": {}}) == {"id": "updated"}
+    assert await client.retrieve("page-id") == {"id": "retrieved"}
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_notion_client_raises_http_exception_for_error_status(
+    respx_mock: respx.Router, settings: Settings
+) -> None:
+    respx_mock.get("https://api.notion.com/v1/pages/missing").mock(
+        return_value=httpx.Response(404, text="not found")
+    )
+
+    client = NotionClient(settings=settings)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await client.retrieve("missing")
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.detail == {"error": "not found"}
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_notion_client_raises_gateway_timeout_on_read_timeout(
+    respx_mock: respx.Router, settings: Settings
+) -> None:
+    respx_mock.post("https://api.notion.com/v1/pages").mock(
+        side_effect=httpx.ReadTimeout("timed out")
+    )
+
+    client = NotionClient(settings=settings)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await client.create({"properties": {}})
+
+    assert exc_info.value.status_code == 504
+    assert exc_info.value.detail == {"error": "Request to Notion timed out"}
+
+
+def test_get_notion_client_returns_notion_client(settings: Settings) -> None:
+    assert isinstance(get_notion_client(settings), NotionClient)

--- a/tests/test_strava_coordinator.py
+++ b/tests/test_strava_coordinator.py
@@ -169,3 +169,54 @@ async def test_coordinator_persist_to_notion() -> None:
     detail = repository.saved_payload["detail"]
     assert detail["description"] == "ride"
     assert isinstance(repository.saved_payload["attachment"], str)
+
+
+@pytest.mark.asyncio
+async def test_coordinator_process_activity_fetches_metrics_and_persists() -> None:
+    repository = DummyWorkoutRepository()
+    repository.athlete_profile = {"max_hr": 190, "ftp": 200}
+
+    class DummyClient:
+        async def get_activity(self, activity_id: int) -> Dict[str, Any]:
+            assert activity_id == 42
+            return {
+                "id": 42,
+                "name": "Ride",
+                "splits_metric": [{"average_heartrate": 150, "moving_time": 60}],
+                "laps": [
+                    {"average_heartrate": 150, "moving_time": 60, "max_heartrate": 170},
+                    {"average_heartrate": 155, "moving_time": 60, "max_heartrate": 175},
+                ],
+                "weighted_average_watts": 210,
+                "moving_time": 120,
+            }
+
+    coordinator = StravaActivityCoordinator(DummyClient(), repository)  # type: ignore[arg-type]
+
+    await coordinator.process_activity(42)
+
+    assert repository.saved_payload is not None
+    assert repository.saved_payload["detail"]["id"] == 42
+    assert repository.saved_payload["tss"] is not None
+    assert repository.saved_payload["intensity_factor"] == pytest.approx(1.05)
+
+
+@pytest.mark.asyncio
+async def test_coordinator_process_activity_wraps_auth_errors() -> None:
+    from fastapi import HTTPException
+    from src.strava.application.ports import StravaAuthError
+
+    repository = DummyWorkoutRepository()
+
+    class DummyClient:
+        async def get_activity(self, activity_id: int) -> Dict[str, Any]:  # noqa: ARG002
+            raise StravaAuthError("expired")
+
+    coordinator = StravaActivityCoordinator(DummyClient(), repository)  # type: ignore[arg-type]
+
+    with pytest.raises(HTTPException) as exc_info:
+        await coordinator.process_activity(42)
+
+    assert exc_info.value.status_code == 500
+    assert exc_info.value.detail == {"error": "Auth failure"}
+    assert repository.saved_payload is None

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+
+from src.models import time as time_model
+
+
+@pytest.mark.parametrize(
+    ("hour", "expected_part"),
+    [
+        (2, "night"),
+        (8, "morning"),
+        (13, "afternoon"),
+        (19, "evening"),
+    ],
+)
+def test_get_local_time_classifies_part_of_day(
+    monkeypatch: pytest.MonkeyPatch, hour: int, expected_part: str
+) -> None:
+    class FixedDateTime(datetime):
+        @classmethod
+        def now(cls, tz=None):  # noqa: ANN001, ANN206
+            return cls(2026, 5, 10, hour, 30, tzinfo=tz)
+
+    monkeypatch.setattr(time_model, "datetime", FixedDateTime)
+
+    local_time, part_of_day = time_model.get_local_time("UTC")
+
+    assert local_time.hour == hour
+    assert local_time.tzinfo is not None
+    assert part_of_day == expected_part

--- a/tests/test_workout_notion.py
+++ b/tests/test_workout_notion.py
@@ -14,6 +14,7 @@ from tests.builders import (
     notion_rich_text,
     notion_title,
 )
+from tests.conftest import NotionAPIStub
 from tests.fakes import NotionWorkoutFake
 
 
@@ -144,3 +145,97 @@ async def test_fill_missing_metrics_updates_notion(
     assert page_id == "page-fill"
     properties = payload["properties"]
     assert {"TSS", "IF", "Type"}.issubset(properties.keys())
+
+
+@pytest.mark.asyncio
+async def test_save_workout_creates_new_notion_page(
+    settings: Settings, notion_api_stub: NotionAPIStub
+) -> None:
+    detail = {
+        "id": 123,
+        "name": "Morning Ride",
+        "start_date": "2026-05-10T12:00:00Z",
+        "elapsed_time": 3600,
+        "distance": 25_000,
+        "total_elevation_gain": 250,
+        "type": "Ride",
+        "average_cadence": 82,
+        "average_watts": 180,
+        "weighted_average_watts": 200,
+        "kilojoules": 650,
+        "calories": 700,
+        "average_heartrate": 145,
+        "max_heartrate": 172,
+        "description": "Sunny endurance ride",
+    }
+    notion_api_stub.expect_query(
+        settings.notion_workout_database_id,
+        {
+            "filter": {"property": "Id", "number": {"equals": 123}},
+            "page_size": 1,
+        },
+        returns={"results": []},
+    ).expect_create(returns={"id": "created-page"})
+    repository = NotionWorkoutAdapter(settings=settings, client=notion_api_stub)
+
+    await repository.save_workout(
+        detail,
+        "attachment",
+        hr_drift=1.5,
+        vo2max=42.0,
+        tss=55.0,
+        intensity_factor=0.75,
+    )
+
+    payload = notion_api_stub.last_create_payload()
+    assert payload is not None
+    assert payload["parent"] == {"database_id": settings.notion_workout_database_id}
+    properties = payload["properties"]
+    assert properties["Name"] == {"title": [{"text": {"content": "Morning Ride"}}]}
+    assert properties["Date"] == {"date": {"start": "2026-05-10"}}
+    assert properties["Day of week"] == {"select": {"name": "Sunday"}}
+    assert properties["Type"] == {"rich_text": [{"text": {"content": "Ride"}}]}
+    assert properties["Notes"] == {
+        "rich_text": [{"text": {"content": "Sunny endurance ride"}}]
+    }
+    assert properties["TSS"] == {"number": 55.0}
+    assert properties["IF"] == {"number": 0.75}
+
+
+@pytest.mark.asyncio
+async def test_save_workout_updates_existing_notion_page(
+    settings: Settings, notion_api_stub: NotionAPIStub
+) -> None:
+    detail = {
+        "id": 456,
+        "name": "Strength",
+        "elapsed_time": 1800,
+        "distance": 0,
+        "total_elevation_gain": 0,
+        "type": None,
+    }
+    notion_api_stub.expect_query(
+        settings.notion_workout_database_id,
+        {
+            "filter": {"property": "Id", "number": {"equals": 456}},
+            "page_size": 1,
+        },
+        returns={"results": [{"id": "existing-page"}]},
+    ).expect_update(page_id="existing-page", returns={"id": "existing-page"})
+    repository = NotionWorkoutAdapter(settings=settings, client=notion_api_stub)
+
+    await repository.save_workout(
+        detail,
+        "attachment",
+        hr_drift=0.0,
+        vo2max=0.0,
+        tss=20.0,
+        intensity_factor=0.5,
+    )
+
+    payload = notion_api_stub.last_update_payload()
+    assert payload is not None
+    properties = payload["properties"]
+    assert properties["Name"] == {"title": [{"text": {"content": "Strength"}}]}
+    assert properties["Type"] == {"rich_text": [{"text": {"content": "Gym"}}]}
+    assert properties["Id"] == {"number": 456}


### PR DESCRIPTION
### Motivation
- Make the health probe record the current probe timestamp and surface the previous probe timestamp to improve observability and debugging of Redis/health checks.
- Update documentation to accurately describe the `/` and `/healthz` behavior and ensure the README matches the implementation.

### Description
- Change `src/main.py` to introduce `HEALTHZ_LAST_CHECK_KEY` and have the health endpoints call `redis.get(...)`, set the current UTC ISO timestamp with `redis.set(...)`, and return `previous_check_at` in the response payload.
- Update the README (`README.md`) to describe that `/` and `/healthz` return the prior Redis-recorded probe timestamp and upsert the current timestamp on each probe.
- Add and update unit tests in `tests/test_healthz.py` to verify that both `/` and `/healthz` return the previous timestamp and record a new UTC ISO timestamp, and adjust the `BrokenRedis` test case to match the new key name; add several new test modules (`tests/test_import_linter_runner.py`, `tests/test_notion_client.py`, `tests/test_strava_coordinator.py`, `tests/test_time.py`, and additions to `tests/test_workout_notion.py`) to expand coverage around import-linter runner, Notion client, Strava coordinator, time helpers, and Notion workout repository interactions.

### Testing
- Ran the test suite with `pytest` (project test runner, e.g. `uv run pytest --cov=src --cov-report=term-missing`) which executed the updated `tests/test_healthz.py` plus the newly added unit tests for Notion, Strava coordinator, import-linter runner, time utilities, and workout-notion adapters.
- All automated tests related to the health endpoint and the newly added test modules completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0055766e288330a87ba53515e8e473)