### PR TITLE
Validate Strava webhook signatures

### DIFF
--- a/src/strava_webhook.py
+++ b/src/strava_webhook.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import hashlib
+import hmac
 import json
 import logging
 from platform import Settings, get_settings
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request
 
 from .platform.wiring import provide_strava_activity_coordinator
 from .strava import StravaActivityCoordinator
@@ -31,11 +33,26 @@ async def verify_subscription(
 @webhook_router.post("/strava-webhook", include_in_schema=False)
 async def strava_event(
     request: Request,
+    x_strava_signature: str | None = Header(default=None, alias="X-Strava-Signature"),
+    settings: Settings = Depends(get_settings),
     service: StravaActivityCoordinator = Depends(
         provide_strava_activity_coordinator
     ),
 ) -> dict[str, str]:
     body = await request.body()
+
+    if x_strava_signature is None:
+        raise HTTPException(
+            status_code=401, detail={"error": "Missing Strava signature"}
+        )
+
+    expected_signature = hmac.new(
+        settings.strava_client_secret.encode(), body, hashlib.sha256
+    ).hexdigest()
+    if not hmac.compare_digest(x_strava_signature, expected_signature):
+        raise HTTPException(
+            status_code=403, detail={"error": "Invalid Strava signature"}
+        )
 
     try:
         event = json.loads(body)

--- a/tests/api/test_strava_webhook.py
+++ b/tests/api/test_strava_webhook.py
@@ -30,7 +30,7 @@ async def test_strava_webhook_verification(client: httpx.AsyncClient, settings: 
 async def test_strava_webhook_event(
     client: httpx.AsyncClient, settings: Settings, strava_coordinator_spy: StravaCoordinatorSpy
 ) -> None:
-    """Triggers activity processing when receiving a create event."""
+    """Triggers activity processing when receiving a signed create event."""
 
     event = make_strava_event(object_id=42)
     body, signature = encode_signed_strava_event(event, client_secret=settings.strava_client_secret)
@@ -44,6 +44,63 @@ async def test_strava_webhook_event(
 
     assert response.status_code == 200
     strava_coordinator_spy.assert_last_process_activity(42)
+
+    unsigned_response = await client.post("/strava-webhook", content=body)
+
+    assert unsigned_response.status_code == 401
+    assert unsigned_response.json() == {"detail": {"error": "Missing Strava signature"}}
+    assert strava_coordinator_spy.processed == [42]
+
+
+@pytest.mark.parametrize(
+    ("signature", "expected_status", "expected_error"),
+    [
+        (None, 401, "Missing Strava signature"),
+        ("not-a-hex-signature", 403, "Invalid Strava signature"),
+    ],
+)
+async def test_strava_webhook_event_rejects_invalid_signatures(
+    client: httpx.AsyncClient,
+    settings: Settings,
+    strava_coordinator_spy: StravaCoordinatorSpy,
+    signature: str | None,
+    expected_status: int,
+    expected_error: str,
+) -> None:
+    """Rejects unsigned or malformed Strava events before processing them."""
+
+    event = make_strava_event(object_id=44)
+    body, _ = encode_signed_strava_event(event, client_secret=settings.strava_client_secret)
+    headers = {} if signature is None else {"X-Strava-Signature": signature}
+
+    response = await client.post("/strava-webhook", content=body, headers=headers)
+
+    assert response.status_code == expected_status
+    assert response.json() == {"detail": {"error": expected_error}}
+    assert strava_coordinator_spy.processed == []
+
+
+async def test_strava_webhook_event_rejects_signature_for_different_payload(
+    client: httpx.AsyncClient, settings: Settings, strava_coordinator_spy: StravaCoordinatorSpy
+) -> None:
+    """Rejects a valid HMAC that was computed for a different event body."""
+
+    event = make_strava_event(object_id=45)
+    tampered_event = make_strava_event(object_id=46)
+    body, _ = encode_signed_strava_event(event, client_secret=settings.strava_client_secret)
+    _, signature = encode_signed_strava_event(
+        tampered_event, client_secret=settings.strava_client_secret
+    )
+
+    response = await client.post(
+        "/strava-webhook",
+        content=body,
+        headers={"X-Strava-Signature": signature},
+    )
+
+    assert response.status_code == 403
+    assert response.json() == {"detail": {"error": "Invalid Strava signature"}}
+    assert strava_coordinator_spy.processed == []
 
 
 async def test_strava_webhook_event_update(


### PR DESCRIPTION
### Motivation
- Ensure the Strava webhook endpoint only processes authentic events by validating an HMAC signature derived from `settings.strava_client_secret`.
- Return explicit error codes for missing or invalid signatures and prevent `StravaCoordinatorSpy.process_activity` from being invoked for rejected requests.

### Description
- Implement HMAC-SHA256 verification in `src/strava_webhook.py:strava_event` using the `X-Strava-Signature` header and `settings.strava_client_secret`.
- Require the header and raise `HTTPException` with status `401` when missing and `403` when the signature does not match, before parsing or processing the payload.
- Add `hashlib`/`hmac` imports and wire a `settings: Settings = Depends(get_settings)` dependency and an `x_strava_signature` header parameter into the endpoint.
- Extend `tests/api/test_strava_webhook.py` with negative tests for missing signature, malformed signature, and a valid HMAC computed for a different payload, asserting the correct `401`/`403` responses and that `process_activity` is not called.

### Testing
- Ran `uv run pytest tests/api/test_strava_webhook.py -q` against the pre-fix implementation and observed failures (confirming the tests detect the missing behavior).
- Re-ran `uv run pytest tests/api/test_strava_webhook.py -q` after the fix and the tests in that file passed.
- Ran the full suite with `uv run pytest -q` and coverage checks `uv run pytest --cov=src --cov-report=term-missing --cov-report=json --cov-fail-under=90` followed by `uv run python scripts/coverage_gate.py coverage.json --total-threshold=90 --per-file-threshold=75`, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a006c0dcbb483308502f01971183829)