### PR TITLE
Strengthen workout metric test expectations

### DIFF
--- a/src/notion/infrastructure/workout_repository.py
+++ b/src/notion/infrastructure/workout_repository.py
@@ -30,13 +30,15 @@ class NotionWorkoutAdapter(WorkoutRepository):
         for page in response.get("results", []):
             workout = self._parse_workout_page(page)
             if workout:
-                workouts.append(
-                    self._augment_with_estimates(
-                        workout,
-                        hr_max_athlete=hr_max_athlete,
-                        hr_rest_athlete=hr_rest_athlete,
-                    )
+                updated = self._augment_with_estimates(
+                    workout,
+                    hr_max_athlete=hr_max_athlete,
+                    hr_rest_athlete=hr_rest_athlete,
                 )
+                props = self._metric_update_props(workout, updated)
+                if props:
+                    await self._client.update(workout.page_id, {"properties": props})
+                workouts.append(updated)
         return workouts
 
     async def fetch_latest_athlete_profile(self) -> Dict[str, Any]:
@@ -159,20 +161,26 @@ class NotionWorkoutAdapter(WorkoutRepository):
             hr_rest_athlete=athlete.get("resting_hr"),
         )
 
+        props = self._metric_update_props(workout, updated)
+        if props:
+            await self._client.update(page_id, {"properties": props})
+
+        return updated
+
+    @classmethod
+    def _metric_update_props(
+        cls, workout: WorkoutLog, updated: WorkoutLog
+    ) -> Dict[str, Any]:
         props: Dict[str, Any] = {}
         if workout.type != updated.type:
             props["Type"] = {
                 "rich_text": [{"text": {"content": updated.type}}]
             }
         if workout.tss != updated.tss:
-            self._add_number_prop(props, "TSS", updated.tss)
+            cls._add_number_prop(props, "TSS", updated.tss)
         if workout.intensity_factor != updated.intensity_factor:
-            self._add_number_prop(props, "IF", updated.intensity_factor)
-
-        if props:
-            await self._client.update(page_id, {"properties": props})
-
-        return updated
+            cls._add_number_prop(props, "IF", updated.intensity_factor)
+        return props
 
     @staticmethod
     def _add_number_prop(

--- a/tests/test_strava_coordinator.py
+++ b/tests/test_strava_coordinator.py
@@ -15,6 +15,11 @@ from src.strava import StravaActivityCoordinator
 from src.strava.domain.metrics import compute_activity_metrics
 from src.strava.infrastructure.client import StravaClientAdapter
 
+EXPECTED_POWER_INTENSITY_FACTOR = 1.05
+EXPECTED_POWER_TSS = 5.5125
+EXPECTED_SHORT_POWER_TSS = 3.675
+EXPECTED_WITHOUT_HR_INTENSITY_FACTOR = 1.0
+EXPECTED_WITHOUT_HR_TSS = 3.3333333333333335
 
 class DummyRedis:
     def __init__(self) -> None:
@@ -115,8 +120,8 @@ def test_compute_activity_metrics() -> None:
     metrics = compute_activity_metrics(activity, athlete)
 
     assert metrics.vo2 == pytest.approx(3.0)
-    assert metrics.intensity_factor == pytest.approx(1.05)
-    assert metrics.tss == pytest.approx(5.5125)
+    assert metrics.intensity_factor == pytest.approx(EXPECTED_POWER_INTENSITY_FACTOR)
+    assert metrics.tss == pytest.approx(EXPECTED_POWER_TSS)
 
 
 def test_compute_activity_metrics_without_heart_rate() -> None:
@@ -143,8 +148,8 @@ def test_compute_activity_metrics_without_heart_rate() -> None:
 
     assert metrics.hr_drift == 0.0
     assert metrics.vo2 == 0.0
-    assert metrics.intensity_factor == pytest.approx(1.0)
-    assert metrics.tss == pytest.approx(3.3333333333333335)
+    assert metrics.intensity_factor == pytest.approx(EXPECTED_WITHOUT_HR_INTENSITY_FACTOR)
+    assert metrics.tss == pytest.approx(EXPECTED_WITHOUT_HR_TSS)
 
 
 @pytest.mark.asyncio
@@ -197,8 +202,10 @@ async def test_coordinator_process_activity_fetches_metrics_and_persists() -> No
 
     assert repository.saved_payload is not None
     assert repository.saved_payload["detail"]["id"] == 42
-    assert repository.saved_payload["tss"] is not None
-    assert repository.saved_payload["intensity_factor"] == pytest.approx(1.05)
+    assert repository.saved_payload["tss"] == pytest.approx(EXPECTED_SHORT_POWER_TSS)
+    assert repository.saved_payload["intensity_factor"] == pytest.approx(
+        EXPECTED_POWER_INTENSITY_FACTOR
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_workout_notion.py
+++ b/tests/test_workout_notion.py
@@ -17,6 +17,20 @@ from tests.builders import (
 from tests.conftest import NotionAPIStub
 from tests.fakes import NotionWorkoutFake
 
+EXPECTED_BACKFILL_INTENSITY_FACTOR = 0.78
+EXPECTED_BACKFILL_TSS = 78.3
+EXPECTED_FILL_INTENSITY_FACTOR = 0.87
+EXPECTED_FILL_TSS = 87.3
+USER_SUPPLIED_INTENSITY_FACTOR = 0.62
+USER_SUPPLIED_TSS = 33.0
+
+
+def assert_metric_update_payload(
+    payload: dict, *, expected_tss: float, expected_intensity_factor: float
+) -> None:
+    properties = payload["properties"]
+    assert properties["TSS"]["number"] == pytest.approx(expected_tss)
+    assert properties["IF"]["number"] == pytest.approx(expected_intensity_factor)
 
 @pytest.mark.asyncio
 async def test_fetch_workouts_includes_minimal_entries(
@@ -98,9 +112,22 @@ async def test_list_recent_workouts_backfills_metrics(
     workouts = await repository.list_recent_workouts(7)
 
     assert workouts[0].type == "Gym"
-    assert workouts[0].tss is not None
-    assert workouts[0].intensity_factor is not None
+    assert workouts[0].tss == pytest.approx(EXPECTED_BACKFILL_TSS)
+    assert workouts[0].intensity_factor == pytest.approx(
+        EXPECTED_BACKFILL_INTENSITY_FACTOR
+    )
     assert workouts[0].page_id == "page-backfill"
+
+    page_id, payload = notion_workout_fake.updates()[-1]
+    assert page_id == "page-backfill"
+    assert payload["properties"]["Type"] == {
+        "rich_text": [{"text": {"content": "Gym"}}]
+    }
+    assert_metric_update_payload(
+        payload,
+        expected_tss=EXPECTED_BACKFILL_TSS,
+        expected_intensity_factor=EXPECTED_BACKFILL_INTENSITY_FACTOR,
+    )
 
 
 @pytest.mark.asyncio
@@ -138,13 +165,19 @@ async def test_fill_missing_metrics_updates_notion(
 
     assert updated is not None
     assert updated.page_id == "page-fill"
-    assert updated.tss is not None
-    assert updated.intensity_factor is not None
+    assert updated.tss == pytest.approx(EXPECTED_FILL_TSS)
+    assert updated.intensity_factor == pytest.approx(EXPECTED_FILL_INTENSITY_FACTOR)
 
     page_id, payload = notion_workout_fake.updates()[-1]
     assert page_id == "page-fill"
     properties = payload["properties"]
     assert {"TSS", "IF", "Type"}.issubset(properties.keys())
+    assert properties["Type"] == {"rich_text": [{"text": {"content": "Gym"}}]}
+    assert_metric_update_payload(
+        payload,
+        expected_tss=EXPECTED_FILL_TSS,
+        expected_intensity_factor=EXPECTED_FILL_INTENSITY_FACTOR,
+    )
 
 
 @pytest.mark.asyncio
@@ -239,3 +272,44 @@ async def test_save_workout_updates_existing_notion_page(
     assert properties["Name"] == {"title": [{"text": {"content": "Strength"}}]}
     assert properties["Type"] == {"rich_text": [{"text": {"content": "Gym"}}]}
     assert properties["Id"] == {"number": 456}
+
+
+@pytest.mark.asyncio
+async def test_fill_missing_metrics_preserves_user_supplied_metrics(
+    settings: Settings,
+    freeze_time,
+    notion_workout_fake: NotionWorkoutFake,
+) -> None:
+    """Existing user-supplied TSS and IF values are not overwritten by estimates."""
+
+    _ = freeze_time
+
+    notion_workout_fake.with_profile(
+        make_notion_profile({"Max HR": notion_number(185)})
+    ).with_workouts(
+        [
+            make_notion_workout(
+                id="page-preserve",
+                properties={
+                    "Name": notion_title("Gym Session"),
+                    "Date": {"date": {"start": "2025-10-10"}},
+                    "Distance [m]": notion_number(0),
+                    "Elevation [m]": notion_number(0),
+                    "Type": notion_rich_text("Gym"),
+                    "Average Heartrate": notion_number(150),
+                    "Max Heartrate": notion_number(175),
+                    "TSS": notion_number(USER_SUPPLIED_TSS),
+                    "IF": notion_number(USER_SUPPLIED_INTENSITY_FACTOR),
+                },
+            )
+        ]
+    )
+
+    repository = NotionWorkoutAdapter(settings=settings, client=notion_workout_fake)
+
+    updated = await repository.fill_missing_metrics("page-preserve")
+
+    assert updated is not None
+    assert updated.tss == pytest.approx(USER_SUPPLIED_TSS)
+    assert updated.intensity_factor == pytest.approx(USER_SUPPLIED_INTENSITY_FACTOR)
+    assert notion_workout_fake.updates() == []

--- a/tests/test_workout_tss_estimation.py
+++ b/tests/test_workout_tss_estimation.py
@@ -6,6 +6,12 @@ from src.application.workouts import CreateManualWorkoutUseCase
 from src.models.workout import ManualWorkoutSubmission
 from src.notion.application.ports import WorkoutRepository
 
+EXPECTED_HR_INTENSITY_FACTOR = 0.86
+EXPECTED_HR_TSS = 85.6
+USER_SUPPLIED_INTENSITY_FACTOR = 0.67
+USER_SUPPLIED_TSS = 42.0
+
+
 class WorkoutRepositoryStub(WorkoutRepository):
     def __init__(self, athlete_profile=None):
         self.athlete_profile = athlete_profile or {}
@@ -14,41 +20,68 @@ class WorkoutRepositoryStub(WorkoutRepository):
     async def fetch_latest_athlete_profile(self):
         return self.athlete_profile
 
-    async def save_workout(self, detail, attachment, hr_drift, vo2max, tss, intensity_factor):
-        self.saved_workouts.append({
-            "detail": detail,
-            "hr_drift": hr_drift,
-            "vo2max": vo2max,
-            "tss": tss,
-            "intensity_factor": intensity_factor
-        })
+    async def save_workout(
+        self, detail, attachment, hr_drift, vo2max, tss, intensity_factor
+    ):
+        self.saved_workouts.append(
+            {
+                "detail": detail,
+                "hr_drift": hr_drift,
+                "vo2max": vo2max,
+                "tss": tss,
+                "intensity_factor": intensity_factor,
+            }
+        )
+
 
 pytestmark = pytest.mark.asyncio
 
+
 async def test_workout_tss_estimation_with_hr():
     """Should correctly estimate TSS and IF when HR data is available."""
-    # Arrange
     repo = WorkoutRepositoryStub(athlete_profile={"max_hr": 190, "resting_hr": 60})
     use_case = CreateManualWorkoutUseCase(repository=repo)
-    
+
     submission = ManualWorkoutSubmission(
         type="Run",
         name="Test Run",
-        start_time="2025-11-06T10:00:00Z",  # Added required field
-        duration_minutes=60,  # Added required field (3600 seconds = 60 minutes)
+        start_time="2025-11-06T10:00:00Z",
+        duration_minutes=60,
         duration_seconds=3600,
         distance_meters=10000,
         average_heartrate=150,
         max_heartrate=170,
-        calories=500
+        calories=500,
     )
 
-    # Act
     result = await use_case(submission)
 
-    # Assert
     assert result.status == "ok"
     assert len(repo.saved_workouts) == 1
     saved = repo.saved_workouts[0]
-    assert saved["tss"] is not None
-    assert saved["intensity_factor"] is not None
+    assert saved["intensity_factor"] == pytest.approx(EXPECTED_HR_INTENSITY_FACTOR)
+    assert saved["tss"] == pytest.approx(EXPECTED_HR_TSS)
+
+
+async def test_workout_tss_estimation_preserves_user_supplied_metrics():
+    """Already calculated user-supplied metrics should not be overwritten."""
+    repo = WorkoutRepositoryStub(athlete_profile={"max_hr": 190, "resting_hr": 60})
+    use_case = CreateManualWorkoutUseCase(repository=repo)
+
+    submission = ManualWorkoutSubmission(
+        name="Manually Scored Run",
+        start_time="2025-11-06T10:00:00Z",
+        duration_minutes=60,
+        distance_meters=10000,
+        average_heartrate=150,
+        max_heartrate=170,
+        calories=500,
+        intensity_factor=USER_SUPPLIED_INTENSITY_FACTOR,
+        tss=USER_SUPPLIED_TSS,
+    )
+
+    await use_case(submission)
+
+    saved = repo.saved_workouts[0]
+    assert saved["intensity_factor"] == pytest.approx(USER_SUPPLIED_INTENSITY_FACTOR)
+    assert saved["tss"] == pytest.approx(USER_SUPPLIED_TSS)


### PR DESCRIPTION
### Motivation
- Make HR-derived IF/TSS behavior explicit and reviewable by asserting exact expected values instead of non-null checks.
- Ensure metric backfills performed by listing and filling work are persisted to Notion and that user-supplied metrics are preserved.

### Description
- Update `NotionWorkoutAdapter.list_recent_workouts` to compute `updated` entries, build a shared update payload via a new `_metric_update_props` helper, and persist changes to Notion when backfills are required.
- Consolidate metric-update logic into a new `@classmethod _metric_update_props(workout, updated)` and reuse it from `fill_missing_metrics`.
- Strengthen tests by introducing named expected constants and asserting exact IF/TSS values with `pytest.approx` in `tests/test_workout_tss_estimation.py`, `tests/test_workout_notion.py`, and `tests/test_strava_coordinator.py`.
- Add tests proving that pre-existing user-supplied `tss` and `intensity_factor` are preserved and do not trigger overwrites or update payloads.
- Add an `assert_metric_update_payload` helper in the Notion tests to assert the Notion update payload contains the expected numeric values.

### Testing
- Ran lint fixes with `uv run ruff check --fix src tests` and validation with `uv run ruff check src tests`, both succeeded.
- Ran the focused tests with `uv run pytest -q tests/test_workout_tss_estimation.py tests/test_workout_notion.py tests/test_strava_coordinator.py` which passed.
- Ran the full test suite with `uv run pytest -q` and the coverage gate with `uv run pytest --cov=src --cov-report=term-missing --cov-report=json --cov-fail-under=90` and `uv run python scripts/coverage_gate.py coverage.json --total-threshold=90 --per-file-threshold=75`, all of which succeeded (all tests passed and coverage gate passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a006ccc06608330a5a2b294b6629dbe)