### PR TITLE
Assert shared test double expectations are consumed

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,6 +82,20 @@ class RedisFake(RedisClient):
         if ex is not None:
             assert last_ex == ex, f"Expected last set ex {ex!r}, saw {last_ex!r}"
 
+    def assert_no_pending_expectations(self) -> None:
+        """Assert all queued Redis expectations were consumed."""
+
+        pending = []
+        pending.extend(
+            f"get(key={key!r}, returns={returns!r})"
+            for key, returns in self._expected_gets
+        )
+        pending.extend(
+            f"set(key={key!r}, value={value!r}, ex={ex!r})"
+            for key, value, ex in self._expected_sets
+        )
+        assert not pending, "Unconsumed Redis expectations: " + "; ".join(pending)
+
     def get(self, key: str) -> Optional[str]:
         self._last_get = key
         if self._expected_gets:
@@ -272,6 +286,17 @@ class NotionAPIStub(NotionAPI):
     def query_history(self) -> list[Dict[str, Any]]:
         return [payload["payload"] for _, payload in self._call_history.get("query", [])]
 
+    def assert_no_pending_expectations(self) -> None:
+        """Assert all queued Notion API expectations were consumed."""
+
+        pending = [
+            f"{method}({expectation.expected!r}, returns={expectation.returns!r}, "
+            f"raises={expectation.raises!r})"
+            for method, expectations in self._expectations.items()
+            for expectation in expectations
+        ]
+        assert not pending, "Unconsumed Notion API expectations: " + "; ".join(pending)
+
     def _last_payload(self, name: str) -> Dict[str, Any] | None:
         if name not in self._last_calls:
             return None
@@ -310,6 +335,21 @@ class WithingsPortFake(WithingsMeasurementsPort):
             assert (
                 self._last_fetch[0] == days
             ), f"Expected fetch_measurements({days}), saw {self._last_fetch[0]}"
+
+    def assert_no_pending_expectations(self) -> None:
+        """Assert all queued Withings expectations were consumed."""
+
+        pending = [
+            f"refresh_access_token({expectation.expected!r}, returns={expectation.returns!r}, "
+            f"raises={expectation.raises!r})"
+            for expectation in self._expected_refresh
+        ]
+        pending.extend(
+            f"fetch_measurements({expectation.expected!r}, returns={expectation.returns!r}, "
+            f"raises={expectation.raises!r})"
+            for expectation in self._expected_fetch
+        )
+        assert not pending, "Unconsumed Withings expectations: " + "; ".join(pending)
 
     async def refresh_access_token(self) -> str:
         self._last_refresh = True
@@ -358,6 +398,15 @@ class StravaCoordinatorSpy:
                 self.processed[-1] == activity_id
             ), f"Expected last processed {activity_id}, saw {self.processed[-1]}"
 
+    def assert_no_pending_expectations(self) -> None:
+        """Assert all queued Strava coordinator expectations were consumed."""
+
+        pending = [
+            f"process_activity({expectation.expected!r}, raises={expectation.raises!r})"
+            for expectation in self._expected_process
+        ]
+        assert not pending, "Unconsumed Strava coordinator expectations: " + "; ".join(pending)
+
     async def process_activity(self, activity_id: int) -> None:
         self.processed.append(activity_id)
         if self._expected_process:
@@ -393,18 +442,24 @@ def settings() -> Settings:
 
 
 @pytest.fixture
-def redis_fake() -> RedisFake:
-    return RedisFake()
+def redis_fake() -> Iterator[RedisFake]:
+    fake = RedisFake()
+    yield fake
+    fake.assert_no_pending_expectations()
 
 
 @pytest.fixture
-def notion_api_stub() -> NotionAPIStub:
-    return NotionAPIStub()
+def notion_api_stub() -> Iterator[NotionAPIStub]:
+    stub = NotionAPIStub()
+    yield stub
+    stub.assert_no_pending_expectations()
 
 
 @pytest.fixture
-def withings_port_fake() -> WithingsPortFake:
-    return WithingsPortFake()
+def withings_port_fake() -> Iterator[WithingsPortFake]:
+    fake = WithingsPortFake()
+    yield fake
+    fake.assert_no_pending_expectations()
 
 
 @pytest.fixture
@@ -415,8 +470,10 @@ def notion_workout_fake(settings: Settings) -> NotionWorkoutFake:
 
 
 @pytest.fixture
-def strava_coordinator_spy() -> StravaCoordinatorSpy:
-    return StravaCoordinatorSpy()
+def strava_coordinator_spy() -> Iterator[StravaCoordinatorSpy]:
+    spy = StravaCoordinatorSpy()
+    yield spy
+    spy.assert_no_pending_expectations()
 
 
 @pytest.fixture

--- a/tests/test_shared_test_doubles.py
+++ b/tests/test_shared_test_doubles.py
@@ -1,0 +1,47 @@
+"""Self-tests for shared test doubles."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.conftest import NotionAPIStub, RedisFake, StravaCoordinatorSpy, WithingsPortFake
+
+
+def test_redis_fake_reports_unconsumed_expectation_payload() -> None:
+    """Unconsumed Redis expectations fail with method and payload details."""
+
+    fake = RedisFake()
+    fake.expect_set("token", "value", ex=60)
+
+    with pytest.raises(AssertionError, match="set\\(key='token', value='value', ex=60\\)"):
+        fake.assert_no_pending_expectations()
+
+
+def test_notion_api_stub_reports_unconsumed_expectation_payload() -> None:
+    """Unconsumed Notion expectations identify the queued method and expected payload."""
+
+    stub = NotionAPIStub()
+    stub.expect_query(database_id="db", payload={"filter": {"property": "Date"}})
+
+    with pytest.raises(AssertionError, match="query.*database_id.*db.*filter"):
+        stub.assert_no_pending_expectations()
+
+
+def test_withings_port_fake_reports_unconsumed_expectation_payload() -> None:
+    """Unconsumed Withings expectations identify the queued method and expected payload."""
+
+    fake = WithingsPortFake()
+    fake.expect_fetch_measurements(days=7, returns=[{"weight": 70}])
+
+    with pytest.raises(AssertionError, match="fetch_measurements.*days.*7.*weight"):
+        fake.assert_no_pending_expectations()
+
+
+def test_strava_coordinator_spy_reports_unconsumed_expectation_payload() -> None:
+    """Unconsumed Strava expectations identify the queued method and expected payload."""
+
+    spy = StravaCoordinatorSpy()
+    spy.expect_process_activity(activity_id=42)
+
+    with pytest.raises(AssertionError, match="process_activity.*activity_id.*42"):
+        spy.assert_no_pending_expectations()


### PR DESCRIPTION
### Motivation
- Ensure tests fail fast and provide actionable error messages when doubles have unconsumed queued expectations.
- Make shared fixtures automatically verify expectations were consumed to avoid silent test flakiness across the suite.

### Description
- Added `assert_no_pending_expectations()` to `RedisFake`, `NotionAPIStub`, `WithingsPortFake`, and `StravaCoordinatorSpy` that formats any remaining queued expectations with method and payload detail for clear assertion messages.
- Converted `redis_fake`, `notion_api_stub`, `withings_port_fake`, and `strava_coordinator_spy` into yield fixtures that call `assert_no_pending_expectations()` in teardown to validate tests consumed their expectations.
- Added `tests/test_shared_test_doubles.py`, a small targeted self-test suite that demonstrates unconsumed expectations raise `AssertionError` including identifying method and payload fragments.
- Reviewed expectation usage across tests and ensured the stricter teardown did not require further changes to existing tests.

### Testing
- Ran the new targeted tests with `uv run pytest -q tests/test_shared_test_doubles.py` and they passed (`4 passed`).
- Ran the full test suite with `uv run pytest -q` and all tests passed (`88 passed`).
- Ran linting with `uv run ruff check --fix src tests` and `uv run ruff check src tests` and both checks passed.
- Ran coverage and the coverage gate (`uv run pytest --cov=src ...` and `uv run python scripts/coverage_gate.py coverage.json --total-threshold=90 --per-file-threshold=75`) and the project met thresholds (total coverage 95.61%).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a006ccdd55483308bda8d65c476668d)