### PR TITLE
Strengthen failure-path test assertions

### DIFF
--- a/tests/api/test_nutrition.py
+++ b/tests/api/test_nutrition.py
@@ -57,6 +57,7 @@ async def test_log_nutrition_error(
     )
 
     assert response.status_code == 500
+    assert response.json() == {"detail": {"error": "boom"}}
 
 
 async def test_get_foods_by_date(
@@ -188,3 +189,4 @@ async def test_get_foods_by_date_timeout(
     )
 
     assert response.status_code == 504
+    assert response.json() == {"detail": {"error": "timeout"}}

--- a/tests/test_strava_client.py
+++ b/tests/test_strava_client.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
-from typing import Callable, Dict, Optional
-
 import httpx
 import pytest
 
@@ -66,53 +64,79 @@ async def test_strava_client_refreshes_access_token_on_401(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "scenario, seed_store, handler",
-    [
-        pytest.param(
-            "missing_token",
-            {},
-            None,
-            id="missing_token",
-        ),
-        pytest.param(
-            "http_error",
-            {"strava_refresh_token": "refresh-token"},
-            lambda request: httpx.Response(500, json={"message": "error"}),
-            id="http_error",
-        ),
-        pytest.param(
-            "missing_access_token",
-            {"strava_refresh_token": "refresh-token"},
-            lambda request: httpx.Response(
-                200, json={"refresh_token": "new-refresh"}
-            ),
-            id="missing_access_token",
-        ),
-    ],
-)
-async def test_strava_refresh_access_token_failure_modes(
-    scenario: str,
-    seed_store: Dict[str, str],
-    handler: Optional[Callable[[httpx.Request], httpx.Response]],
+async def test_strava_refresh_access_token_without_refresh_token(
     settings: Settings,
     freeze_time,
     redis_fake: RedisFake,
 ) -> None:
-    """Refreshing the Strava token surfaces storage and HTTP failures."""
+    """A missing Strava refresh token fails before touching cached tokens."""
 
     _ = freeze_time
-    redis_fake.store.update(seed_store)
 
-    transport_handler = handler or (lambda _: httpx.Response(204))
-
-    async with httpx.AsyncClient(transport=httpx.MockTransport(transport_handler)) as http_client:
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(lambda _: httpx.Response(204))
+    ) as http_client:
         strava_client = StravaClientAdapter(http_client, redis_fake, settings)
-        with pytest.raises(StravaAuthError):
+        with pytest.raises(
+            StravaAuthError, match="No Strava refresh token found in Redis"
+        ):
             await strava_client._refresh_access_token()
 
-    if scenario == "missing_token":
-        assert not redis_fake.expirations
+    assert redis_fake.store == {}
+    assert redis_fake.expirations == {}
+
+
+@pytest.mark.asyncio
+async def test_strava_refresh_access_token_http_error_preserves_cache(
+    settings: Settings,
+    freeze_time,
+    redis_fake: RedisFake,
+) -> None:
+    """HTTP token-refresh failures do not partially update Redis."""
+
+    _ = freeze_time
+    redis_fake.store["strava_refresh_token"] = "refresh-token"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "POST"
+        return httpx.Response(500, json={"message": "error"})
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http_client:
+        strava_client = StravaClientAdapter(http_client, redis_fake, settings)
+        with pytest.raises(
+            StravaAuthError, match="Failed to refresh Strava access token"
+        ):
+            await strava_client._refresh_access_token()
+
+    assert redis_fake.store == {"strava_refresh_token": "refresh-token"}
+    assert redis_fake.expirations == {}
+
+
+@pytest.mark.asyncio
+async def test_strava_refresh_access_token_missing_access_token_preserves_cache(
+    settings: Settings,
+    freeze_time,
+    redis_fake: RedisFake,
+) -> None:
+    """Malformed token-refresh payloads do not partially update Redis."""
+
+    _ = freeze_time
+    redis_fake.store["strava_refresh_token"] = "refresh-token"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "POST"
+        return httpx.Response(200, json={"refresh_token": "new-refresh"})
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http_client:
+        strava_client = StravaClientAdapter(http_client, redis_fake, settings)
+        with pytest.raises(
+            StravaAuthError,
+            match="Strava token refresh response missing access token",
+        ):
+            await strava_client._refresh_access_token()
+
+    assert redis_fake.store == {"strava_refresh_token": "refresh-token"}
+    assert redis_fake.expirations == {}
 
 
 @pytest.mark.asyncio

--- a/tests/test_withings_client.py
+++ b/tests/test_withings_client.py
@@ -76,10 +76,14 @@ async def test_refresh_access_token_success(respx_mock: respx.Router) -> None:
 @pytest.mark.asyncio
 @respx.mock
 async def test_refresh_access_token_without_refresh_token(respx_mock: respx.Router) -> None:
-    client = WithingsMeasurementsAdapter(redis=RecordingRedis(), settings=TEST_SETTINGS)
+    redis = RecordingRedis()
+    client = WithingsMeasurementsAdapter(redis=redis, settings=TEST_SETTINGS)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="No Withings refresh token found in Redis"):
         await client.refresh_access_token()
+
+    assert redis.store == {}
+    assert redis.expirations == {}
 
 
 @pytest.mark.asyncio
@@ -93,8 +97,11 @@ async def test_refresh_access_token_http_error(respx_mock: respx.Router) -> None
 
     client = WithingsMeasurementsAdapter(redis=redis, settings=TEST_SETTINGS)
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises(RuntimeError, match="Failed to refresh Withings access token"):
         await client.refresh_access_token()
+
+    assert redis.store == {"withings_refresh_token": "refresh-token"}
+    assert redis.expirations == {}
 
 
 @pytest.mark.asyncio
@@ -111,8 +118,11 @@ async def test_refresh_access_token_error_status(respx_mock: respx.Router) -> No
 
     client = WithingsMeasurementsAdapter(redis=redis, settings=TEST_SETTINGS)
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises(RuntimeError, match="Withings API error: boom"):
         await client.refresh_access_token()
+
+    assert redis.store == {"withings_refresh_token": "refresh-token"}
+    assert redis.expirations == {}
 
 
 @pytest.mark.asyncio
@@ -126,8 +136,13 @@ async def test_refresh_access_token_missing_access_token(respx_mock: respx.Route
 
     client = WithingsMeasurementsAdapter(redis=redis, settings=TEST_SETTINGS)
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises(
+        RuntimeError, match="Withings refresh response missing access token"
+    ):
         await client.refresh_access_token()
+
+    assert redis.store == {"withings_refresh_token": "refresh-token"}
+    assert redis.expirations == {}
 
 
 @pytest.mark.asyncio
@@ -233,5 +248,5 @@ async def test_fetch_measurements_raises_on_api_error(respx_mock: respx.Router) 
 
     client = WithingsMeasurementsAdapter(redis=redis, settings=TEST_SETTINGS)
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises(RuntimeError, match="Withings API error: boom"):
         await client.fetch_measurements(days=1)


### PR DESCRIPTION
### Motivation
- Tests used broad `pytest.raises(RuntimeError)` assertions that did not verify the error message contract.
- HTTP API tests only checked status codes instead of asserting the full JSON error body where the route contract defines one.
- Token-refresh failure cases could leave Redis/cache in an unclear state and multiple failure reasons were grouped under a single parametrized test.

### Description
- Updated `tests/test_withings_client.py` to assert specific exception messages for missing refresh token, HTTP refresh failures, API status errors, missing access token, and measurement API errors using `pytest.raises(..., match=...)` and added Redis state assertions to ensure cache was not partially updated.
- Reworked `tests/test_strava_client.py` to replace the parametrized failure test with three focused tests that separately cover missing refresh token, HTTP token-refresh failure, and missing access-token in the refresh response, each asserting the propagated error message and that Redis state is preserved.
- Modified `tests/api/test_nutrition.py` to assert the full JSON error response body for failing routes (e.g., `{

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a006cee9b6c833084adcbbc067cc417)