### PR TITLE
Add OpenAPI schema synchronization coverage

### DIFF
--- a/generate_openapi.py
+++ b/generate_openapi.py
@@ -3,22 +3,12 @@
 import json
 from pathlib import Path
 
-from src.main import app
+from src.main import app, build_openapi_schema
 
 
 def generate_openapi() -> None:
     """Write the current OpenAPI schema to ``openapi.json``."""
-    schema = app.openapi()
-    schema["servers"] = [
-        {"url": "https://notionuploader-groa.onrender.com"}
-    ]
-
-    # Mark all operations as non-consequential so they can be always allowed
-    for path_item in schema.get("paths", {}).values():
-        for operation in path_item.values():
-            if isinstance(operation, dict):
-                operation["x-openai-isConsequential"] = False
-                operation["is_consequential"] = False
+    schema = build_openapi_schema(app)
     output_path = Path(__file__).resolve().parent / "openapi.json"
     output_path.write_text(json.dumps(schema, indent=2))
 

--- a/src/main.py
+++ b/src/main.py
@@ -17,6 +17,7 @@ from .routes.workouts import router as workouts_router
 from .strava_webhook import webhook_router
 
 HEALTHZ_LAST_CHECK_KEY = "healthz:last_check_at"
+OPENAPI_HTTP_METHODS = {"get", "put", "post", "delete", "options", "head", "patch", "trace"}
 
 
 app: FastAPI = FastAPI(
@@ -56,11 +57,21 @@ async def healthz(redis: RedisClient = Depends(get_redis)) -> dict[str, str | No
 @app.get("/v2/api-schema")
 async def get_api_schema(request: Request, _: Any = Depends(verify_api_key)) -> JSONResponse:
     """Return the OpenAPI schema for this API version."""
-    openapi_schema: Dict[str, Any] = request.app.openapi()
+    return JSONResponse(build_openapi_schema(request.app))
+
+
+def build_openapi_schema(fastapi_app: FastAPI) -> Dict[str, Any]:
+    """Return the published OpenAPI schema with API contract extensions."""
+    openapi_schema: Dict[str, Any] = fastapi_app.openapi()
     openapi_schema["servers"] = [
         {"url": "https://notionuploader-groa.onrender.com"}
     ]
-    return JSONResponse(openapi_schema)
+    for path_item in openapi_schema.get("paths", {}).values():
+        for method, operation in path_item.items():
+            if method in OPENAPI_HTTP_METHODS and isinstance(operation, dict):
+                operation["x-openai-isConsequential"] = False
+                operation["is_consequential"] = False
+    return openapi_schema
 
 
 for router in (

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -33,7 +33,7 @@ async def test_api_schema_auth_contract(
 
 
 async def test_openapi_schema(client: httpx.AsyncClient, settings: Settings) -> None:
-    """The generated schema defines the API key security scheme only once."""
+    """The schema route exposes the committed API key and OpenAI metadata contract."""
 
     response = await client.get("/v2/api-schema", headers={"x-api-key": settings.api_key})
 
@@ -43,5 +43,9 @@ async def test_openapi_schema(client: httpx.AsyncClient, settings: Settings) -> 
     assert schema["components"]["securitySchemes"]["ApiKeyAuth"]["name"] == "x-api-key"
     for path_item in schema["paths"].values():
         for operation in path_item.values():
-            if isinstance(operation, dict) and "parameters" in operation:
+            if not isinstance(operation, dict):
+                continue
+            assert operation["x-openai-isConsequential"] is False
+            assert operation["is_consequential"] is False
+            if "parameters" in operation:
                 assert all(parameter["name"] != "x-api-key" for parameter in operation["parameters"])

--- a/tests/test_openapi_generation.py
+++ b/tests/test_openapi_generation.py
@@ -1,0 +1,42 @@
+"""Tests for committed OpenAPI schema synchronization."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from src.main import app, build_openapi_schema
+
+
+def test_committed_openapi_schema_matches_generated_contract() -> None:
+    """The committed schema stays synchronized with the app contract."""
+
+    cached_schema = app.openapi_schema
+    try:
+        app.openapi_schema = None
+        generated_schema = build_openapi_schema(app)
+    finally:
+        app.openapi_schema = cached_schema
+    committed_schema = json.loads(Path("openapi.json").read_text())
+
+    assert generated_schema == committed_schema
+
+
+def test_every_committed_openapi_operation_is_non_consequential() -> None:
+    """OpenAI action metadata marks every operation as non-consequential."""
+
+    schema = json.loads(Path("openapi.json").read_text())
+
+    for path, method, operation in _iter_operations(schema):
+        assert operation["x-openai-isConsequential"] is False, (path, method)
+        assert operation["is_consequential"] is False, (path, method)
+
+
+def _iter_operations(schema: dict[str, Any]) -> list[tuple[str, str, dict[str, Any]]]:
+    operations: list[tuple[str, str, dict[str, Any]]] = []
+    for path, path_item in schema.get("paths", {}).items():
+        for method, operation in path_item.items():
+            if isinstance(operation, dict):
+                operations.append((path, method, operation))
+    return operations


### PR DESCRIPTION
### Motivation
- Ensure the published OpenAPI contract (committed `openapi.json`) and the runtime `/v2/api-schema` response are generated by the same logic so they remain synchronized.
- Add automated coverage that verifies the committed schema equals a generated schema and that every operation exposes the OpenAI consequential metadata.

### Description
- Introduce `build_openapi_schema(fastapi_app: FastAPI)` in `src/main.py` which sets the `servers` URL and decorates every OpenAPI operation with `x-openai-isConsequential: false` and `is_consequential: false` for HTTP methods in `OPENAPI_HTTP_METHODS`.
- Update the `/v2/api-schema` route to return the output of `build_openapi_schema` so the route and file generation share the same builder.
- Modify `generate_openapi.py` to call `build_openapi_schema(app)` instead of duplicating mutation logic and write the resulting schema to `openapi.json`.
- Add `tests/test_openapi_generation.py` that builds the schema in-memory, compares it to the committed `openapi.json`, and asserts every operation includes both non-consequential flags; and update `tests/api/test_auth.py` to verify the route response includes the same flags.

### Testing
- Ran `uv run ruff check --fix src tests` and `uv run ruff check src tests`, both completed with no remaining fixable issues.
- Ran `uv run python generate_openapi.py` to regenerate `openapi.json` using the shared builder, which completed successfully.
- Ran `uv run pytest -q` and all tests passed (`86 passed`), with the new tests included.
- Ran coverage and gate commands `uv run pytest --cov=src --cov-report=...` and `uv run python scripts/coverage_gate.py coverage.json --total-threshold=90 --per-file-threshold=75`, and the coverage gate passed (total coverage >= 90%).
- Ran `uv run import-linter`, which produced no contract failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a006cef870c8330ab3350cd93f9aa77)