### PR TITLE
Validate IANA timezones, improve workout payload retention and Notion workout schema handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ uv run python generate_openapi.py
 
 `GET /v2/advice-context?days=28&timezone=Europe/Prague` returns one explicit local-calendar window containing nutrition coverage, recorded-past-day statistics, daily body representatives, training totals separated by sport and load family, direct cross-domain joins, source statuses, quality issues, and raw evidence. Missing data is represented as `null` or explicit missing dates; it is never silently converted to zero. Use `include_entries=false` to omit raw food entries, or `include_workout_details=true` to request recently retained interval details.
 
-The endpoint performs bookkeeping only. It does not infer causality, food quality, workout success, or coaching priorities. Existing workout rows without provenance remain labelled as unknown, while new Intervals.icu syncs preserve provider identity, start timestamps, load origin, and a 120-day compressed payload reference.
+The endpoint performs bookkeeping only. It does not infer causality, food quality, workout success, or coaching priorities. Existing workout rows without provenance remain labelled as unknown, while new Intervals.icu syncs preserve provider identity, start timestamps, load origin, and a 120-day compressed payload reference when Redis retention is available. Invalid `timezone` query values are rejected with HTTP 422 instead of falling back silently or surfacing a server error.
 
 ## Configuration Reference
 Define the following variables (case insensitive thanks to `SettingsConfigDict(case_sensitive=False)`):
@@ -79,6 +79,7 @@ Run the import boundary checks, linter, and coverage-enabled tests before every 
 - **Review the README**: Treat this document as the source of truth for setup and deployment. Re-read it after each change and update any sections impacted by your modifications before merging.
 
 ## Deployment Notes
+- Before enabling Intervals.icu workout provenance in a workspace, run `uv run python scripts/ensure_notion_workout_schema.py` to install the additive workout properties (`Start Time`, `External ID`, `Provider Source`, `Provider Client`, `Device`, `Payload Key`, `TSS Origin`, and `Load Family`). The command is idempotent, prints a secret-free summary, and exits non-zero for type conflicts. Runtime writes still degrade to the legacy property set if the extension schema is missing or cannot be inspected.
 - Render deploys this service via webhook; health checks hit `/healthz`, which reads the previous Redis-recorded probe timestamp and upserts the current timestamp on each probe.
 - The production OpenAPI schema is exposed at `/v2/api-schema` with the server URL pre-set to Render (`https://notionuploader-groa.onrender.com`).
 - Ensure any schema or dependency changes are committed together so the Render build installs the correct versions from `uv.lock`.
@@ -110,7 +111,7 @@ Required configuration:
 
 The endpoint accepts `lookback_days=1..365`. Use the default seven-day rolling scan for normal cron operation, and larger bounded calls such as `lookback_days=365` for deliberate onboarding or Apple Watch historical backfill. The sync is idempotent: direct Intervals activities use negative numeric Notion IDs derived from Intervals IDs, while Intervals Companion activities use the exact UTC start timestamp to merge with manual Apple Watch uploads when the manual upload used the same instant.
 
-The existing Notion schema remains backward compatible. New syncs may populate `Start Time`, provider identity, `TSS Origin`, `Load Family`, and `Payload Key` properties alongside the legacy fields. The advice context never adds incompatible load families into one total; HR-estimated load is not reported as cycling TSS.
+The existing Notion schema remains backward compatible. New syncs may populate `Start Time`, provider identity, `TSS Origin`, `Load Family`, and `Payload Key` properties alongside the legacy fields after the migration command has installed compatible Notion properties. If Upstash payload retention is unavailable, the workout is still saved to Notion, sync results report `payloads_retained` and `payload_retention_failures`, and advice-context details report structured unavailability issues instead of failing the whole response. The advice context never adds incompatible load families into one total; HR-estimated load is not reported as cycling TSS, and timestamped workouts are attributed to the requested IANA timezone for range filtering, grouping, streaks, windows, and cross-domain joins.
 
 Linux cron example:
 

--- a/openapi.json
+++ b/openapi.json
@@ -103,6 +103,9 @@
             "schema": {
               "type": "string",
               "description": "IANA timezone for local time, defaults to Prague.",
+              "examples": [
+                "Europe/Prague"
+              ],
               "default": "Europe/Prague",
               "title": "Timezone"
             },
@@ -174,6 +177,9 @@
             "schema": {
               "type": "string",
               "description": "IANA timezone for local time, defaults to Prague.",
+              "examples": [
+                "Europe/Prague"
+              ],
               "default": "Europe/Prague",
               "title": "Timezone"
             },
@@ -426,18 +432,6 @@
             "description": "Inclusive calendar days of analytical context."
           },
           {
-            "name": "timezone",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "description": "IANA timezone for local time, defaults to Prague.",
-              "default": "Europe/Prague",
-              "title": "Timezone"
-            },
-            "description": "IANA timezone for local time, defaults to Prague."
-          },
-          {
             "name": "include_entries",
             "in": "query",
             "required": false,
@@ -460,6 +454,21 @@
               "title": "Include Workout Details"
             },
             "description": "Include stored interval details when available."
+          },
+          {
+            "name": "timezone",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "IANA timezone for local time, defaults to Prague.",
+              "examples": [
+                "Europe/Prague"
+              ],
+              "default": "Europe/Prague",
+              "title": "Timezone"
+            },
+            "description": "IANA timezone for local time, defaults to Prague."
           }
         ],
         "responses": {
@@ -517,6 +526,9 @@
             "schema": {
               "type": "string",
               "description": "IANA timezone for local time, defaults to Prague.",
+              "examples": [
+                "Europe/Prague"
+              ],
               "default": "Europe/Prague",
               "title": "Timezone"
             },
@@ -1681,6 +1693,16 @@
             },
             "type": "array",
             "title": "Failures"
+          },
+          "payloads_retained": {
+            "type": "integer",
+            "title": "Payloads Retained",
+            "default": 0
+          },
+          "payload_retention_failures": {
+            "type": "integer",
+            "title": "Payload Retention Failures",
+            "default": 0
           }
         },
         "type": "object",

--- a/scripts/ensure_notion_workout_schema.py
+++ b/scripts/ensure_notion_workout_schema.py
@@ -9,12 +9,13 @@ from typing import Any
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "src"))
 
+from platform.config import get_settings  # noqa: E402
+
 from notion.infrastructure.workout_schema import (  # noqa: E402
     WORKOUT_EXTENSION_SCHEMA,
     classify_workout_schema,
     notion_property_definition,
 )
-from platform.config import get_settings  # noqa: E402
 from services.notion import NotionClient  # noqa: E402
 
 
@@ -39,7 +40,9 @@ async def main() -> int:
             name: notion_property_definition(WORKOUT_EXTENSION_SCHEMA[name])
             for name in compatibility.missing
         }
-        await client.update_database(settings.notion_workout_database_id, {"properties": properties})
+        await client.update_database(
+                settings.notion_workout_database_id, {"properties": properties}
+        )
         final = classify_workout_schema(
             await client.retrieve_database(settings.notion_workout_database_id)
         )

--- a/scripts/ensure_notion_workout_schema.py
+++ b/scripts/ensure_notion_workout_schema.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from notion.infrastructure.workout_schema import (  # noqa: E402
+    WORKOUT_EXTENSION_SCHEMA,
+    classify_workout_schema,
+    notion_property_definition,
+)
+from platform.config import get_settings  # noqa: E402
+from services.notion import NotionClient  # noqa: E402
+
+
+async def main() -> int:
+    settings = get_settings()
+    client = NotionClient(settings=settings)
+    database = await client.retrieve_database(settings.notion_workout_database_id)
+    compatibility = classify_workout_schema(database)
+    summary: dict[str, Any] = {
+        "database": "workout",
+        "status": "complete",
+        "added": [],
+        "already_present": sorted(compatibility.compatible),
+        "type_conflicts": sorted(compatibility.type_conflicts),
+    }
+    if compatibility.type_conflicts:
+        summary["status"] = "type_conflict"
+        print(json.dumps(summary, sort_keys=True))
+        return 1
+    if compatibility.missing:
+        properties = {
+            name: notion_property_definition(WORKOUT_EXTENSION_SCHEMA[name])
+            for name in compatibility.missing
+        }
+        await client.update_database(settings.notion_workout_database_id, {"properties": properties})
+        final = classify_workout_schema(
+            await client.retrieve_database(settings.notion_workout_database_id)
+        )
+        summary["added"] = sorted(compatibility.missing)
+        summary["already_present"] = sorted(final.compatible)
+        summary["type_conflicts"] = sorted(final.type_conflicts)
+        summary["status"] = "updated"
+        if final.missing or final.type_conflicts:
+            summary["status"] = "incomplete"
+            print(json.dumps(summary, sort_keys=True))
+            return 1
+    print(json.dumps(summary, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        exit_code = asyncio.run(main())
+    except Exception as exc:
+        # Deliberately omit exception messages: HTTP clients and settings
+        # validation errors can contain database identifiers or credentials.
+        print(
+            json.dumps(
+                {
+                    "database": "workout",
+                    "status": "error",
+                    "error_code": "NOTION_SCHEMA_OPERATION_FAILED",
+                    "error_class": type(exc).__name__,
+                },
+                sort_keys=True,
+            )
+        )
+        exit_code = 1
+    raise SystemExit(exit_code)

--- a/src/application/advice_context.py
+++ b/src/application/advice_context.py
@@ -82,7 +82,7 @@ class GetAdviceContextUseCase:
         measurements = body_raw if isinstance(body_raw, list) else []
         workouts = workouts_raw if isinstance(workouts_raw, list) else []
         detail_issues: list[DataQualityIssue] = []
-        if include_workout_details and self.payload_store is not None:
+        if include_workout_details:
             workouts, detail_issues = await self._add_workout_details(workouts)
         profile = _profile_model(profile_raw if not isinstance(profile_raw, Exception) else {})
         nutrition, nutrition_issues = analyze_nutrition(
@@ -155,47 +155,30 @@ class GetAdviceContextUseCase:
         enriched: list[WorkoutLog] = []
         issues: list[DataQualityIssue] = []
         for workout in workouts:
-            if not workout.payload_key or self.payload_store is None:
+            if not workout.payload_key:
                 enriched.append(workout)
-                issues.append(
-                    DataQualityIssue(
-                        code="TRAINING_WORKOUT_DETAILS_UNAVAILABLE",
-                        domain="training",
-                        severity="info",
-                        message="Structured interval details were not retained for this workout.",
-                        affected_record_ids=[workout.page_id],
-                    )
-                )
+                issues.append(_workout_detail_issue(workout, "info", "not_retained"))
                 continue
-            payload = await self.payload_store.get(workout.payload_key)
-            if payload is None:
+            if self.payload_store is None:
                 enriched.append(workout)
-                issues.append(
-                    DataQualityIssue(
-                        code="TRAINING_WORKOUT_DETAILS_UNAVAILABLE",
-                        domain="training",
-                        severity="info",
-                        message="The retained workout payload is no longer available.",
-                        affected_record_ids=[workout.page_id],
-                    )
-                )
+                issues.append(_workout_detail_issue(workout, "warning", "store_unavailable"))
                 continue
             try:
-                decoded = gzip.decompress(base64.b64decode(payload)).decode()
-                detail = json.loads(decoded)
-                intervals = detail.get("splits_metric") or detail.get("laps") or []
-                enriched.append(workout.model_copy(update={"intervals": intervals}))
-            except (ValueError, TypeError, OSError, json.JSONDecodeError):
+                payload = await self.payload_store.get(workout.payload_key)
+            except Exception:
                 enriched.append(workout)
-                issues.append(
-                    DataQualityIssue(
-                        code="TRAINING_WORKOUT_DETAILS_UNAVAILABLE",
-                        domain="training",
-                        severity="warning",
-                        message="The retained workout payload could not be decoded.",
-                        affected_record_ids=[workout.page_id],
-                    )
-                )
+                issues.append(_workout_detail_issue(workout, "warning", "store_unavailable"))
+                continue
+            if payload is None:
+                enriched.append(workout)
+                issues.append(_workout_detail_issue(workout, "info", "expired"))
+                continue
+            try:
+                intervals = _decode_workout_intervals(payload)
+                enriched.append(workout.model_copy(update={"intervals": intervals}))
+            except (ValueError, TypeError, OSError, UnicodeDecodeError, json.JSONDecodeError):
+                enriched.append(workout)
+                issues.append(_workout_detail_issue(workout, "warning", "decode_failed"))
         return enriched, issues
 
     def _generated_at(self) -> datetime:
@@ -244,3 +227,30 @@ def _source_issues(statuses: list[SourceStatus]) -> list[DataQualityIssue]:
 
 
 __all__ = ["GetAdviceContextUseCase"]
+
+
+def _workout_detail_issue(workout: WorkoutLog, severity: str, reason: str) -> DataQualityIssue:
+    return DataQualityIssue(
+        code="TRAINING_WORKOUT_DETAILS_UNAVAILABLE",
+        domain="training",
+        severity=severity,
+        message="Structured interval details are unavailable for this workout.",
+        affected_record_ids=[workout.page_id],
+        details={"reason": reason},
+    )
+
+
+def _decode_workout_intervals(payload: str) -> list[Any]:
+    decoded = gzip.decompress(base64.b64decode(payload)).decode()
+    detail = json.loads(decoded)
+    if not isinstance(detail, dict):
+        raise ValueError("payload top-level value is not an object")
+    if "splits_metric" in detail:
+        intervals = detail["splits_metric"]
+    elif "laps" in detail:
+        intervals = detail["laps"]
+    else:
+        intervals = []
+    if not isinstance(intervals, list):
+        raise ValueError("payload intervals are not a list")
+    return intervals

--- a/src/domain/advice/cross_domain.py
+++ b/src/domain/advice/cross_domain.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import date
 
+from ...domain.advice.dates import workout_local_date
 from ...models.advice_context import (
     AnalysisWindow,
     BodyAnalysis,
@@ -12,6 +13,7 @@ from ...models.advice_context import (
     NutritionAnalysis,
     TrainingAnalysis,
 )
+from ...models.workout import WorkoutLog
 
 
 def analyze_cross_domain(
@@ -31,7 +33,7 @@ def analyze_cross_domain(
         workout_count = training_day.workout_count if training_day else 0
         duration = training_day.duration_s if training_day else 0.0
         exercise_kcal = training_day.kcal if training_day else (0.0 if workout_count == 0 else None)
-        coverage = training_day_kcal_coverage(training_day, training)
+        coverage = training_day_kcal_coverage(training_day, training, window.timezone)
         ffm_date, ffm = _latest_ffm(day, body_by_date)
         complete = (
             nutrition_day.calories_kcal is not None
@@ -66,7 +68,9 @@ def analyze_cross_domain(
     return CrossDomainAnalysis(daily=daily)
 
 
-def training_day_kcal_coverage(day: object | None, training: TrainingAnalysis) -> float:
+def training_day_kcal_coverage(
+    day: object | None, training: TrainingAnalysis, timezone_name: str = "UTC"
+) -> float:
     """Return the fraction of workouts with an exercise-calorie value."""
     if day is None:
         return 1.0
@@ -79,11 +83,20 @@ def training_day_kcal_coverage(day: object | None, training: TrainingAnalysis) -
     if training_day is None:
         return 0.0
     workouts = [
-        workout for workout in training.workouts if workout.date[:10] == str(training_day.date)
+        workout
+        for workout in training.workouts
+        if _workout_date(workout, timezone_name) == getattr(training_day, "date")
     ]
     if not workouts:
         return 0.0
     return sum(workout.kcal is not None for workout in workouts) / len(workouts)
+
+
+def _workout_date(workout: WorkoutLog, timezone_name: str) -> date | None:
+    try:
+        return workout_local_date(workout, timezone_name)
+    except ValueError:
+        return None
 
 
 def _latest_ffm(day: date, body_by_date: dict[date, object]) -> tuple[date | None, float | None]:

--- a/src/domain/advice/dates.py
+++ b/src/domain/advice/dates.py
@@ -1,0 +1,18 @@
+"""Canonical workout local-calendar date handling."""
+
+from __future__ import annotations
+
+from datetime import date
+from zoneinfo import ZoneInfo
+
+from ...models.workout import WorkoutLog
+
+
+def workout_local_date(workout: WorkoutLog, timezone_name: str) -> date:
+    if workout.start_time is not None:
+        if workout.start_time.tzinfo is None or workout.start_time.utcoffset() is None:
+            raise ValueError("workout start_time must be timezone-aware")
+        return workout.start_time.astimezone(ZoneInfo(timezone_name)).date()
+    if not isinstance(workout.date, str) or len(workout.date) < 10:
+        raise ValueError("workout date is unavailable")
+    return date.fromisoformat(workout.date[:10])

--- a/src/domain/advice/quality.py
+++ b/src/domain/advice/quality.py
@@ -2,21 +2,41 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+from datetime import date, datetime
+from typing import Any
+
 from ...models.advice_context import DataQualityIssue
 
 
 def merge_quality_issues(issues: list[DataQualityIssue]) -> list[DataQualityIssue]:
-    """Merge duplicate issue identities while preserving deterministic order."""
-    merged: dict[tuple[str, str, str, tuple[str, ...]], DataQualityIssue] = {}
+    """Merge only semantically identical issues while preserving first-seen order."""
+    merged: dict[tuple[Any, ...], DataQualityIssue] = {}
     for issue in issues:
-        key = (issue.code, issue.domain, issue.severity, tuple(issue.affected_record_ids))
+        key = (
+            issue.code,
+            issue.domain,
+            issue.severity,
+            issue.message,
+            tuple(issue.affected_record_ids),
+            _canonical(issue.details),
+        )
         if key not in merged:
-            merged[key] = issue
+            merged[key] = issue.model_copy(deep=True)
             continue
         existing = merged[key]
         existing.affected_dates = sorted(set(existing.affected_dates + issue.affected_dates))
-        existing.details = {**existing.details, **issue.details}
     return list(merged.values())
+
+
+def _canonical(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return tuple((key, _canonical(value[key])) for key in sorted(value))
+    if isinstance(value, list):
+        return tuple(_canonical(item) for item in value)
+    if isinstance(value, datetime | date):
+        return value.isoformat()
+    return value
 
 
 __all__ = ["merge_quality_issues"]

--- a/src/domain/advice/training.py
+++ b/src/domain/advice/training.py
@@ -15,6 +15,7 @@ from ...models.advice_context import (
     TrainingWindowSummary,
 )
 from ...models.workout import WorkoutLog
+from .dates import workout_local_date
 
 
 def analyze_training(
@@ -24,24 +25,43 @@ def analyze_training(
     selected = [
         workout
         for workout in workouts
-        if window.start_date <= _workout_date(workout) <= window.end_date
+        if _safe_workout_date(workout, window.timezone) is not None
+        and window.start_date <= _workout_date(workout, window.timezone) <= window.end_date
     ]
     daily_by_date: dict[date, list[WorkoutLog]] = defaultdict(list)
     for workout in selected:
-        daily_by_date[_workout_date(workout)].append(workout)
+        daily_by_date[_workout_date(workout, window.timezone)].append(workout)
     daily = [_daily_summary(day, daily_by_date[day]) for day in sorted(daily_by_date)]
     windows: list[TrainingWindowSummary] = []
     for size in (4, 7, 14, 28):
-        if window.requested_days >= size:
+        if window.requested_days > size:
             start = window.end_date - timedelta(days=size - 1)
             windows.append(
                 _window_summary(
-                    start, window.end_date, [w for w in selected if start <= _workout_date(w)]
+                    start,
+                    window.end_date,
+                    [w for w in selected if start <= _workout_date(w, window.timezone)],
+                    window.timezone,
                 ),
             )
-    windows.append(_window_summary(window.start_date, window.end_date, selected))
+    windows.append(_window_summary(window.start_date, window.end_date, selected, window.timezone))
     concentrations = _concentrations(selected, window)
     issues: list[DataQualityIssue] = []
+    invalid_ids = [
+        workout.page_id
+        for workout in workouts
+        if _safe_workout_date(workout, window.timezone) is None
+    ]
+    if invalid_ids:
+        issues.append(
+            DataQualityIssue(
+                code="TRAINING_WORKOUT_DATE_INVALID",
+                domain="training",
+                severity="warning",
+                message="Some workouts have no valid analytical calendar date.",
+                affected_record_ids=invalid_ids,
+            )
+        )
     families = {
         family for workout in selected if (family := _load_family(workout)) != "unknown_load"
     }
@@ -104,7 +124,9 @@ def _daily_summary(day: date, workouts: list[WorkoutLog]) -> DailyTrainingSummar
     )
 
 
-def _window_summary(start: date, end: date, workouts: list[WorkoutLog]) -> TrainingWindowSummary:
+def _window_summary(
+    start: date, end: date, workouts: list[WorkoutLog], timezone_name: str = "UTC"
+) -> TrainingWindowSummary:
     duration: dict[str, float] = defaultdict(float)
     counts: dict[str, int] = defaultdict(int)
     loads: dict[str, float] = defaultdict(float)
@@ -115,7 +137,7 @@ def _window_summary(start: date, end: date, workouts: list[WorkoutLog]) -> Train
         if workout.tss is not None:
             loads[_load_family(workout)] += workout.tss
     kcal_values = [workout.kcal for workout in workouts if workout.kcal is not None]
-    training_days = {_workout_date(workout) for workout in workouts}
+    training_days = {_workout_date(workout, timezone_name) for workout in workouts}
     return TrainingWindowSummary(
         start_date=start,
         end_date=end,
@@ -149,7 +171,7 @@ def _concentrations(workouts: list[WorkoutLog], window: AnalysisWindow) -> list[
         recent = sum(
             workout.tss or 0
             for workout in workouts
-            if recent_start <= _workout_date(workout)
+            if recent_start <= _workout_date(workout, window.timezone)
             and _sport_group(workout) == sport
             and _load_family(workout) == family
         )
@@ -166,8 +188,15 @@ def _concentrations(workouts: list[WorkoutLog], window: AnalysisWindow) -> list[
     return result
 
 
-def _workout_date(workout: WorkoutLog) -> date:
-    return date.fromisoformat(workout.date[:10])
+def _safe_workout_date(workout: WorkoutLog, timezone_name: str) -> date | None:
+    try:
+        return workout_local_date(workout, timezone_name)
+    except ValueError:
+        return None
+
+
+def _workout_date(workout: WorkoutLog, timezone_name: str) -> date:
+    return workout_local_date(workout, timezone_name)
 
 
 def _sport_group(workout: WorkoutLog) -> str:

--- a/src/intervals_icu/application/coordinator.py
+++ b/src/intervals_icu/application/coordinator.py
@@ -38,6 +38,8 @@ class IntervalsSyncResult(BaseModel):
     failed: int
     skipped_by_reason: dict[str, int] = Field(default_factory=dict)
     failures: list[IntervalsSyncFailure] = Field(default_factory=list)
+    payloads_retained: int = 0
+    payload_retention_failures: int = 0
 
 
 class IntervalsSyncCoordinator:
@@ -71,6 +73,8 @@ class IntervalsSyncCoordinator:
         logger.info("Intervals.icu discovered=%s eligible=%s", len(activities), len(eligible))
         athlete = await self._workouts.fetch_latest_athlete_profile()
         processed = 0
+        payloads_retained = 0
+        payload_retention_failures = 0
         failures: list[IntervalsSyncFailure] = []
         for activity in eligible:
             activity_id = activity.get("id") if isinstance(activity.get("id"), str) else None
@@ -84,9 +88,20 @@ class IntervalsSyncCoordinator:
                 minified = json.dumps(detail, separators=(",", ":"), default=str)
                 attachment = base64.b64encode(gzip.compress(minified.encode())).decode()
                 payload_key = workout_payload_key("intervals_icu", mapped.external_id)
-                detail["payload_key"] = payload_key
                 if self._payload_store is not None:
-                    await self._payload_store.put(payload_key, attachment)
+                    try:
+                        await self._payload_store.put(payload_key, attachment)
+                    except Exception as exc:  # best-effort evidence retention
+                        payload_retention_failures += 1
+                        logger.warning(
+                            "Workout payload retention failed activity_id=%s "
+                            "code=WORKOUT_PAYLOAD_STORE_UNAVAILABLE error_class=%s",
+                            activity_id,
+                            type(exc).__name__,
+                        )
+                    else:
+                        payloads_retained += 1
+                        detail["payload_key"] = payload_key
                 await self._workouts.save_workout(
                     detail,
                     attachment,
@@ -120,6 +135,8 @@ class IntervalsSyncCoordinator:
             failed=failed,
             skipped_by_reason=dict(skipped),
             failures=failures,
+            payloads_retained=payloads_retained,
+            payload_retention_failures=payload_retention_failures,
         )
         logger.info(
             "Intervals.icu sync completed processed=%s skipped=%s failed=%s",

--- a/src/notion/infrastructure/workout_repository.py
+++ b/src/notion/infrastructure/workout_repository.py
@@ -1,14 +1,20 @@
 from __future__ import annotations
 
+import logging
 from datetime import date, datetime, timedelta, timezone
 from platform.config import Settings
 from typing import Any, Dict, List, Optional
 
+from ...domain.advice.dates import workout_local_date
 from ...domain.body_metrics.hr import estimate_if_tss_from_hr
 from ...models.advice_context import AdviceAthleteProfile
 from ...models.workout import WorkoutLog
 from ...services.interfaces import NotionAPI
 from ..application.ports import WorkoutRepository
+from .workout_schema import WorkoutSchemaCompatibility, classify_workout_schema
+
+logger = logging.getLogger(__name__)
+BOUNDARY_DATE_PADDING_DAYS = 1
 
 
 class NotionWorkoutAdapter(WorkoutRepository):
@@ -17,6 +23,7 @@ class NotionWorkoutAdapter(WorkoutRepository):
     def __init__(self, *, settings: Settings, client: NotionAPI) -> None:
         self._settings = settings
         self._client = client
+        self._extension_schema: WorkoutSchemaCompatibility | None = None
 
     async def list_recent_workouts(self, days: int) -> List[WorkoutLog]:
         start = (datetime.now(timezone.utc) - timedelta(days=days)).date().isoformat()
@@ -44,12 +51,13 @@ class NotionWorkoutAdapter(WorkoutRepository):
         self, start_date: date, end_date: date, timezone_name: str
     ) -> List[WorkoutLog]:
         """Read every workout page in an explicit range without mutating Notion."""
-        _ = timezone_name
+        padded_start = start_date - timedelta(days=BOUNDARY_DATE_PADDING_DAYS)
+        padded_end = end_date + timedelta(days=BOUNDARY_DATE_PADDING_DAYS)
         payload: Dict[str, Any] = {
             "filter": {
                 "and": [
-                    {"property": "Date", "date": {"on_or_after": start_date.isoformat()}},
-                    {"property": "Date", "date": {"on_or_before": end_date.isoformat()}},
+                    {"property": "Date", "date": {"on_or_after": padded_start.isoformat()}},
+                    {"property": "Date", "date": {"on_or_before": padded_end.isoformat()}},
                 ]
             }
         }
@@ -59,7 +67,15 @@ class NotionWorkoutAdapter(WorkoutRepository):
             for page in response.get("results", []):
                 workout = self._parse_workout_page(page)
                 if workout is not None:
-                    workouts.append(workout)
+                    try:
+                        local_date = workout_local_date(workout, timezone_name)
+                    except ValueError:
+                        # Keep malformed candidates so the domain analyzer can report
+                        # TRAINING_WORKOUT_DATE_INVALID instead of silently losing them.
+                        workouts.append(workout)
+                        continue
+                    if start_date <= local_date <= end_date:
+                        workouts.append(workout)
             if not response.get("has_more"):
                 break
             payload["start_cursor"] = response.get("next_cursor")
@@ -139,14 +155,16 @@ class NotionWorkoutAdapter(WorkoutRepository):
             "Id": {"number": detail["id"]},
             "Day of week": {"select": {"name": day_of_week}},
         }
-        self._add_date_prop(props, "Start Time", detail.get("start_date"))
-        self._add_text_prop(props, "External ID", detail.get("external_id"))
-        self._add_text_prop(props, "Provider Source", detail.get("provider_source"))
-        self._add_text_prop(props, "Provider Client", detail.get("provider_client_name"))
-        self._add_text_prop(props, "Device", detail.get("device_name"))
-        self._add_text_prop(props, "Payload Key", detail.get("payload_key"))
-        self._add_text_prop(props, "TSS Origin", tss_origin)
-        self._add_text_prop(props, "Load Family", load_family)
+        extension_props: Dict[str, Any] = {}
+        self._add_date_prop(extension_props, "Start Time", detail.get("start_date"))
+        self._add_text_prop(extension_props, "External ID", detail.get("external_id"))
+        self._add_text_prop(extension_props, "Provider Source", detail.get("provider_source"))
+        self._add_text_prop(extension_props, "Provider Client", detail.get("provider_client_name"))
+        self._add_text_prop(extension_props, "Device", detail.get("device_name"))
+        self._add_text_prop(extension_props, "Payload Key", detail.get("payload_key"))
+        self._add_text_prop(extension_props, "TSS Origin", tss_origin)
+        self._add_text_prop(extension_props, "Load Family", load_family)
+        props.update(await self._compatible_extension_props(extension_props))
 
         self._add_number_prop(props, "Average Cadence", detail.get("average_cadence"))
         self._add_number_prop(props, "Average Watts", detail.get("average_watts"))
@@ -182,6 +200,42 @@ class NotionWorkoutAdapter(WorkoutRepository):
             "properties": props,
         }
         await self._client.create(payload)
+
+    async def _compatible_extension_props(self, props: Dict[str, Any]) -> Dict[str, Any]:
+        compatibility = await self._extension_schema_compatibility()
+        return {name: value for name, value in props.items() if name in compatibility.compatible}
+
+    async def _extension_schema_compatibility(self) -> WorkoutSchemaCompatibility:
+        if self._extension_schema is not None:
+            return self._extension_schema
+        try:
+            database = await self._client.retrieve_database(
+                self._settings.notion_workout_database_id
+            )
+            compatibility = classify_workout_schema(database)
+        except Exception as exc:
+            compatibility = WorkoutSchemaCompatibility(
+                compatible=frozenset(),
+                missing=(),
+                type_conflicts=(),
+                unavailable=True,
+            )
+            logger.warning(
+                "Notion workout extension schema unavailable; "
+                "writing legacy workout properties only error_class=%s",
+                type(exc).__name__,
+            )
+        else:
+            if compatibility.missing or compatibility.type_conflicts:
+                logger.warning(
+                    "Notion workout extension schema incomplete; "
+                    "writing compatible extension properties only "
+                    "missing=%s type_conflicts=%s",
+                    list(compatibility.missing),
+                    list(compatibility.type_conflicts),
+                )
+        self._extension_schema = compatibility
+        return compatibility
 
     async def _estimate_metrics(self, detail: Dict[str, Any]) -> Optional[tuple[float, float]]:
         athlete = await self.fetch_latest_athlete_profile()
@@ -297,7 +351,9 @@ class NotionWorkoutAdapter(WorkoutRepository):
                 page_id=str(page.get("id") or ""),
                 name=_get_title("Name"),
                 date=_get_date("Date"),
-                start_time=_parse_datetime(_get_date("Start Time") or _get_date("Date")),
+                # A legacy Date is a calendar value, not an instant.  Treating it as
+                # midnight UTC would move it to the previous day in western zones.
+                start_time=_parse_datetime(_get_date("Start Time")),
                 external_id=_get_text("External ID"),
                 provider_source=_get_text("Provider Source"),
                 provider_client_name=_get_text("Provider Client"),

--- a/src/notion/infrastructure/workout_schema.py
+++ b/src/notion/infrastructure/workout_schema.py
@@ -1,0 +1,49 @@
+"""Shared Notion workout extension schema manifest and helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+WORKOUT_EXTENSION_SCHEMA: dict[str, str] = {
+    "Start Time": "date",
+    "External ID": "rich_text",
+    "Provider Source": "rich_text",
+    "Provider Client": "rich_text",
+    "Device": "rich_text",
+    "Payload Key": "rich_text",
+    "TSS Origin": "rich_text",
+    "Load Family": "rich_text",
+}
+
+
+@dataclass(frozen=True)
+class WorkoutSchemaCompatibility:
+    compatible: frozenset[str]
+    missing: tuple[str, ...]
+    type_conflicts: tuple[str, ...]
+    unavailable: bool = False
+
+
+def classify_workout_schema(database: dict[str, Any]) -> WorkoutSchemaCompatibility:
+    properties = database.get("properties", {}) if isinstance(database, dict) else {}
+    compatible: list[str] = []
+    missing: list[str] = []
+    conflicts: list[str] = []
+    for name, expected_type in WORKOUT_EXTENSION_SCHEMA.items():
+        payload = properties.get(name)
+        if payload is None:
+            missing.append(name)
+        elif payload.get("type") == expected_type:
+            compatible.append(name)
+        else:
+            conflicts.append(name)
+    return WorkoutSchemaCompatibility(
+        compatible=frozenset(compatible),
+        missing=tuple(missing),
+        type_conflicts=tuple(conflicts),
+    )
+
+
+def notion_property_definition(notion_type: str) -> dict[str, Any]:
+    return {notion_type: {}}

--- a/src/routes/advice.py
+++ b/src/routes/advice.py
@@ -7,7 +7,7 @@ from ..application.advice_context import GetAdviceContextUseCase
 from ..models.advice import SummaryAdvice
 from ..models.advice_context import AdviceContext
 from ..platform.wiring import get_advice_context_use_case, get_summary_advice_use_case
-from .utils import timezone_query
+from .utils import validated_timezone
 
 router: APIRouter = APIRouter()
 
@@ -15,7 +15,7 @@ router: APIRouter = APIRouter()
 @router.get("/advice-context", response_model=AdviceContext)
 async def get_advice_context(
     days: int = Query(7, ge=1, le=90, description="Inclusive calendar days of analytical context."),
-    timezone: str = timezone_query,
+    timezone: str = Depends(validated_timezone),
     include_entries: bool = Query(
         True, description="Include raw nutrition entries in daily evidence."
     ),
@@ -36,7 +36,7 @@ async def get_advice_context(
 @router.get("/summary-advice", response_model=SummaryAdvice)
 async def get_summary_advice(
     days: int = Query(7, description="Number of days of data to retrieve."),
-    timezone: str = timezone_query,
+    timezone: str = Depends(validated_timezone),
     use_case: GetSummaryAdviceUseCase = Depends(get_summary_advice_use_case),
 ) -> SummaryAdvice:
     return await use_case(days, timezone)

--- a/src/routes/nutrition.py
+++ b/src/routes/nutrition.py
@@ -14,7 +14,7 @@ from ..platform.wiring import (
     get_daily_nutrition_entries_use_case,
     get_nutrition_entries_by_period_use_case,
 )
-from .utils import timezone_query
+from .utils import validated_timezone
 
 router: APIRouter = APIRouter()
 
@@ -33,7 +33,7 @@ async def create_nutrition_entry(
 )
 async def list_daily_nutrition_entries(
     date: str = Path(..., description="Date to fetch in YYYY-MM-DD format."),
-    timezone: str = timezone_query,
+    timezone: str = Depends(validated_timezone),
     use_case: GetDailyNutritionEntriesUseCase = Depends(get_daily_nutrition_entries_use_case),
 ) -> NutritionSummaryResponse:
     return await use_case(date, timezone)
@@ -52,7 +52,7 @@ async def list_nutrition_entries_by_period(
         ...,
         description="End date (inclusive) in YYYY-MM-DD format.",
     ),
-    timezone: str = timezone_query,
+    timezone: str = Depends(validated_timezone),
     use_case: GetNutritionEntriesByPeriodUseCase = Depends(
         get_nutrition_entries_by_period_use_case
     ),

--- a/src/routes/utils.py
+++ b/src/routes/utils.py
@@ -1,6 +1,39 @@
-from fastapi import Query
+from __future__ import annotations
 
-timezone_query = Query(
-    default="Europe/Prague",
-    description="IANA timezone for local time, defaults to Prague.",
-)
+from typing import Annotated
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from fastapi import Depends, Query
+from fastapi.exceptions import RequestValidationError
+
+
+def _timezone_validation_error(value: object) -> RequestValidationError:
+    return RequestValidationError(
+        [
+            {
+                "type": "timezone",
+                "loc": ("query", "timezone"),
+                "msg": "Unknown IANA timezone",
+                "input": value,
+            }
+        ]
+    )
+
+
+async def validated_timezone(
+    timezone: str = Query(
+        default="Europe/Prague",
+        description="IANA timezone for local time, defaults to Prague.",
+        examples=["Europe/Prague"],
+    ),
+) -> str:
+    if not timezone:
+        raise _timezone_validation_error(timezone)
+    try:
+        ZoneInfo(timezone)
+    except ZoneInfoNotFoundError as exc:
+        raise _timezone_validation_error(timezone) from exc
+    return timezone
+
+
+timezone_query = Annotated[str, Depends(validated_timezone)]

--- a/src/services/interfaces.py
+++ b/src/services/interfaces.py
@@ -23,6 +23,12 @@ class NotionAPI(Protocol):
     async def retrieve(self, page_id: str) -> Dict[str, Any]:
         """Fetch a page by its identifier."""
 
+    async def retrieve_database(self, database_id: str) -> Dict[str, Any]:
+        """Fetch a database schema by its identifier."""
+
+    async def update_database(self, database_id: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+        """Update a database schema and return the updated object."""
+
 
 @runtime_checkable
 class StravaAPI(Protocol):

--- a/src/services/notion.py
+++ b/src/services/notion.py
@@ -50,6 +50,14 @@ class NotionClient(NotionAPI):
         resp = await self._request("GET", f"/pages/{page_id}")
         return resp.json()
 
+    async def retrieve_database(self, database_id: str) -> Dict[str, Any]:
+        resp = await self._request("GET", f"/databases/{database_id}")
+        return resp.json()
+
+    async def update_database(self, database_id: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+        resp = await self._request("PATCH", f"/databases/{database_id}", json=payload)
+        return resp.json()
+
 
 def get_notion_client(settings: Settings = Depends(get_settings)) -> NotionAPI:
     """Dependency that provides a configured Notion API client."""

--- a/tests/api/test_advice_context_api.py
+++ b/tests/api/test_advice_context_api.py
@@ -70,3 +70,37 @@ async def test_advice_context_route_exposes_stable_contract(client, app, setting
 
     assert response.status_code == 200
     assert response.json()["context_version"] == "2.0"
+
+
+@pytest.mark.parametrize(
+    "path,params",
+    [
+        ("/v2/advice-context", {"timezone": "Invalid/Zone"}),
+        ("/v2/summary-advice", {"timezone": "Invalid/Zone"}),
+        ("/v2/nutrition-entries/daily/2026-07-16", {"timezone": "Invalid/Zone"}),
+        (
+            "/v2/nutrition-entries/period",
+            {
+                "start_date": "2026-07-15",
+                "end_date": "2026-07-16",
+                "timezone": "Invalid/Zone",
+            },
+        ),
+    ],
+)
+async def test_timezone_aware_routes_reject_unknown_zone(
+    client, settings, path: str, params: dict[str, str]
+) -> None:
+    response = await client.get(path, params=params, headers={"x-api-key": settings.api_key})
+
+    assert response.status_code == 422
+    assert response.json() == {
+        "detail": [
+            {
+                "type": "timezone",
+                "loc": ["query", "timezone"],
+                "msg": "Unknown IANA timezone",
+                "input": "Invalid/Zone",
+            }
+        ]
+    }

--- a/tests/domain/advice/test_training.py
+++ b/tests/domain/advice/test_training.py
@@ -74,3 +74,30 @@ def test_cross_domain_does_not_screen_without_complete_exercise_calories() -> No
     joined = analyze_cross_domain(nutrition, body, training, window)
 
     assert joined.daily[0].screening_energy_availability_kcal_per_kg_ffm is None
+
+
+def test_training_windows_are_unique_for_standard_request_size() -> None:
+    window = build_analysis_window(
+        days=7,
+        timezone_name="UTC",
+        clock=lambda: datetime(2026, 7, 16, 12, tzinfo=timezone.utc),
+    )
+
+    training, _ = analyze_training([], window)
+
+    assert [item.calendar_days for item in training.windows] == [4, 7]
+    assert len({(item.start_date, item.end_date) for item in training.windows}) == 2
+
+
+def test_training_uses_timestamp_in_requested_timezone() -> None:
+    workout = _workout("2026-07-15", "Ride", "provider_training_load", 100, 500)
+    workout = workout.model_copy(update={"start_time": datetime(2026, 7, 15, 23, 30, tzinfo=timezone.utc)})
+    window = build_analysis_window(
+        days=1,
+        timezone_name="Europe/Prague",
+        clock=lambda: datetime(2026, 7, 16, 12, tzinfo=timezone.utc),
+    )
+
+    training, _ = analyze_training([workout], window)
+
+    assert [day.date.isoformat() for day in training.daily] == ["2026-07-16"]

--- a/tests/fakes/notion.py
+++ b/tests/fakes/notion.py
@@ -17,6 +17,8 @@ class NotionWorkoutFake(NotionAPI):
         self._profile: Dict[str, Any] | None = None
         self._pages: Dict[str, Dict[str, Any]] = {}
         self._updates: List[Tuple[str, Dict[str, Any]]] = []
+        self.database_schema: Dict[str, Any] = {"properties": {}}
+        self.database_updates: List[Dict[str, Any]] = []
 
     def with_workouts(self, workouts: Iterable[Dict[str, Any]]) -> "NotionWorkoutFake":
         """Seed the fake with workout pages returned by the query API."""
@@ -61,3 +63,15 @@ class NotionWorkoutFake(NotionAPI):
 
     async def retrieve(self, page_id: str) -> Dict[str, Any]:
         return self._pages.get(page_id, {"id": page_id, "properties": {}})
+
+    async def retrieve_database(self, database_id: str) -> Dict[str, Any]:
+        _ = database_id
+        return self.database_schema
+
+    async def update_database(
+        self, database_id: str, payload: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        _ = database_id
+        self.database_updates.append(payload)
+        self.database_schema.setdefault("properties", {}).update(payload.get("properties", {}))
+        return self.database_schema

--- a/tests/test_advice_context.py
+++ b/tests/test_advice_context.py
@@ -124,3 +124,122 @@ async def test_context_returns_503_when_all_analytical_sources_fail() -> None:
     with pytest.raises(HTTPException) as raised:
         await use_case(days=1, timezone="UTC")
     assert raised.value.status_code == 503
+
+class PayloadStore:
+    def __init__(self, values):
+        self.values = values
+
+    async def put(self, key: str, value: str) -> None:
+        self.values[key] = value
+
+    async def get(self, key: str) -> str | None:
+        value = self.values[key]
+        if isinstance(value, Exception):
+            raise value
+        return value
+
+
+class DetailWorkouts(Workouts):
+    def __init__(self, payload_keys: list[str | None]) -> None:
+        self.payload_keys = payload_keys
+
+    async def list_workouts_in_range(self, start_date, end_date, timezone_name):
+        return [
+            WorkoutLog(
+                page_id=f"ride-{index}",
+                name="Ride",
+                date="2026-07-15",
+                duration_s=3600,
+                distance_m=1000,
+                elevation_m=10,
+                type="Ride",
+                kcal=500,
+                tss=100,
+                tss_origin="provider",
+                load_family="provider_training_load",
+                payload_key=payload_key,
+            )
+            for index, payload_key in enumerate(self.payload_keys)
+        ]
+
+
+@pytest.mark.asyncio
+async def test_context_enriches_workout_details_and_reports_partial_payload_failures() -> None:
+    import base64
+    import gzip
+    import json
+
+    valid = base64.b64encode(
+        gzip.compress(json.dumps({"laps": [{"distance": 1}]}).encode())
+    ).decode()
+    use_case = GetAdviceContextUseCase(
+        nutrition_repository=Nutrition(),
+        withings_port=Body(),
+        workout_repository=DetailWorkouts(["valid", None, "expired", "broken", "store"]),
+        clock=clock,
+        payload_store=PayloadStore(
+            {
+                "valid": valid,
+                "expired": None,
+                "broken": "not-gzip-json",
+                "store": RuntimeError("redis://secret-token"),
+            }
+        ),
+    )
+
+    context = await use_case(days=2, timezone="UTC", include_workout_details=True)
+
+    assert context.training.workouts[0].intervals == [{"distance": 1}]
+    reasons = [
+        issue.details["reason"]
+        for issue in context.quality_issues
+        if issue.code == "TRAINING_WORKOUT_DETAILS_UNAVAILABLE"
+    ]
+    assert reasons == ["not_retained", "expired", "decode_failed", "store_unavailable"]
+
+
+@pytest.mark.asyncio
+async def test_context_reports_configured_payload_key_when_store_is_unavailable() -> None:
+    use_case = GetAdviceContextUseCase(
+        nutrition_repository=Nutrition(),
+        withings_port=Body(),
+        workout_repository=DetailWorkouts(["retained-key"]),
+        clock=clock,
+        payload_store=None,
+    )
+
+    context = await use_case(days=2, timezone="UTC", include_workout_details=True)
+
+    issue = next(
+        item
+        for item in context.quality_issues
+        if item.code == "TRAINING_WORKOUT_DETAILS_UNAVAILABLE"
+    )
+    assert issue.details == {"reason": "store_unavailable"}
+
+
+@pytest.mark.asyncio
+async def test_context_rejects_non_list_primary_interval_collection() -> None:
+    import base64
+    import gzip
+    import json
+
+    payload = base64.b64encode(
+        gzip.compress(json.dumps({"splits_metric": {}, "laps": []}).encode())
+    ).decode()
+    use_case = GetAdviceContextUseCase(
+        nutrition_repository=Nutrition(),
+        withings_port=Body(),
+        workout_repository=DetailWorkouts(["malformed"]),
+        clock=clock,
+        payload_store=PayloadStore({"malformed": payload}),
+    )
+
+    context = await use_case(days=2, timezone="UTC", include_workout_details=True)
+
+    assert context.training.workouts[0].intervals is None
+    assert any(
+        item.details == {"reason": "decode_failed"}
+        for item in context.quality_issues
+        if item.code == "TRAINING_WORKOUT_DETAILS_UNAVAILABLE"
+    )

--- a/tests/test_advice_quality.py
+++ b/tests/test_advice_quality.py
@@ -26,3 +26,26 @@ def test_quality_issues_merge_dates_for_same_identity() -> None:
 
     assert len(merged) == 1
     assert merged[0].affected_dates == [date(2026, 7, 14), date(2026, 7, 15)]
+
+
+def test_quality_issues_with_different_details_do_not_merge() -> None:
+    issues = [
+        DataQualityIssue(
+            code="SOURCE_PARTIAL_FAILURE",
+            domain="cross_domain",
+            severity="warning",
+            message="source unavailable",
+            details={"source": "nutrition", "error_code": "UPSTREAM_UNAVAILABLE"},
+        ),
+        DataQualityIssue(
+            code="SOURCE_PARTIAL_FAILURE",
+            domain="cross_domain",
+            severity="warning",
+            message="source unavailable",
+            details={"source": "withings", "error_code": "UPSTREAM_UNAVAILABLE"},
+        ),
+    ]
+
+    merged = merge_quality_issues(issues)
+
+    assert [item.details["source"] for item in merged] == ["nutrition", "withings"]

--- a/tests/test_workout_notion.py
+++ b/tests/test_workout_notion.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from datetime import date
+
 import pytest
 
 from src.notion.infrastructure.workout_repository import NotionWorkoutAdapter
@@ -270,6 +272,55 @@ async def test_save_workout_updates_existing_notion_page(
 
 
 @pytest.mark.asyncio
+async def test_range_read_preserves_legacy_calendar_date_in_negative_timezone(
+    settings: Settings, notion_workout_fake: NotionWorkoutFake
+) -> None:
+    notion_workout_fake.with_workouts(
+        [
+            make_notion_workout(
+                id="legacy-page",
+                properties={
+                    "Name": notion_title("Legacy ride"),
+                    "Date": {"date": {"start": "2026-07-15"}},
+                },
+            )
+        ]
+    )
+    repository = NotionWorkoutAdapter(settings=settings, client=notion_workout_fake)
+
+    workouts = await repository.list_workouts_in_range(
+        date(2026, 7, 15), date(2026, 7, 15), "America/New_York"
+    )
+
+    assert [workout.page_id for workout in workouts] == ["legacy-page"]
+    assert workouts[0].start_time is None
+
+
+@pytest.mark.asyncio
+async def test_range_read_keeps_invalid_date_for_domain_diagnostics(
+    settings: Settings, notion_workout_fake: NotionWorkoutFake
+) -> None:
+    notion_workout_fake.with_workouts(
+        [
+            make_notion_workout(
+                id="invalid-page",
+                properties={
+                    "Name": notion_title("Malformed legacy ride"),
+                    "Date": {"date": {"start": "not-a-date"}},
+                },
+            )
+        ]
+    )
+    repository = NotionWorkoutAdapter(settings=settings, client=notion_workout_fake)
+
+    workouts = await repository.list_workouts_in_range(
+        date(2026, 7, 15), date(2026, 7, 15), "UTC"
+    )
+
+    assert [workout.page_id for workout in workouts] == ["invalid-page"]
+
+
+@pytest.mark.asyncio
 async def test_fill_missing_metrics_preserves_user_supplied_metrics(
     settings: Settings,
     freeze_time,
@@ -308,3 +359,74 @@ async def test_fill_missing_metrics_preserves_user_supplied_metrics(
     assert updated.tss == pytest.approx(USER_SUPPLIED_TSS)
     assert updated.intensity_factor == pytest.approx(USER_SUPPLIED_INTENSITY_FACTOR)
     assert notion_workout_fake.updates() == []
+
+
+@pytest.mark.asyncio
+async def test_save_workout_filters_missing_extension_schema(
+    settings: Settings,
+    notion_workout_fake: NotionWorkoutFake,
+) -> None:
+    notion_workout_fake.database_schema = {"properties": {}}
+    repository = NotionWorkoutAdapter(settings=settings, client=notion_workout_fake)
+
+    await repository.save_workout(
+        {
+            "id": 123,
+            "name": "Ride",
+            "start_date": "2026-07-15T12:00:00+00:00",
+            "elapsed_time": 60,
+            "moving_time": 60,
+            "distance": 1,
+            "total_elevation_gain": 0,
+            "type": "Ride",
+            "payload_key": "secret-free-key",
+        },
+        "attachment",
+        0,
+        0,
+    )
+
+    props = notion_workout_fake._pages["created-page"]["properties"]
+    assert "Date" in props
+    assert "Payload Key" not in props
+
+
+@pytest.mark.asyncio
+async def test_save_workout_writes_complete_extension_schema(
+    settings: Settings,
+    notion_workout_fake: NotionWorkoutFake,
+) -> None:
+    notion_workout_fake.database_schema = {
+        "properties": {
+            "Start Time": {"type": "date"},
+            "Payload Key": {"type": "rich_text"},
+            "TSS Origin": {"type": "rich_text"},
+            "Load Family": {"type": "rich_text"},
+            "External ID": {"type": "rich_text"},
+            "Provider Source": {"type": "rich_text"},
+            "Provider Client": {"type": "rich_text"},
+            "Device": {"type": "rich_text"},
+        }
+    }
+    repository = NotionWorkoutAdapter(settings=settings, client=notion_workout_fake)
+
+    await repository.save_workout(
+        {
+            "id": 456,
+            "name": "Ride",
+            "start_date": "2026-07-15T12:00:00+00:00",
+            "elapsed_time": 60,
+            "moving_time": 60,
+            "distance": 1,
+            "total_elevation_gain": 0,
+            "type": "Ride",
+            "payload_key": "payload-key",
+        },
+        "attachment",
+        0,
+        0,
+    )
+
+    props = notion_workout_fake._pages["created-page"]["properties"]
+    assert props["Start Time"] == {"date": {"start": "2026-07-15T12:00:00+00:00"}}
+    assert props["Payload Key"] == {"rich_text": [{"text": {"content": "payload-key"}}]}


### PR DESCRIPTION
### Motivation

- Ensure API clients cannot pass unknown IANA timezone names and avoid silent fallbacks or server errors when timezone input is invalid.
- Make Intervals.icu workout payload retention best-effort so syncs still succeed when Upstash/Redis is unavailable and surface retention diagnostics in sync results and advice context quality issues.
- Add tooling to install the additive Notion workout properties and make Notion repository writes tolerant of missing or incompatible extension schema.

### Description

- Add a `validated_timezone` dependency and replace the previous `timezone_query` usage in routes so invalid `timezone` inputs return HTTP 422 and examples/defaults are added to the OpenAPI schema.
- Implement timezone-aware workout date handling via `src/domain/advice/dates.py` and propagate timezone-aware grouping into `training` and `cross_domain` analysis functions so workouts are attributed to the requested calendar date for filtering and windows.
- Make workout detail enrichment resilient: `GetAdviceContextUseCase` now reports structured `TRAINING_WORKOUT_DETAILS_UNAVAILABLE` issues with `reason` values (`not_retained`, `expired`, `decode_failed`, `store_unavailable`) and decodes payloads via `_decode_workout_intervals` with stricter validation.
- Change Intervals.icu sync coordinator to attempt best-effort payload retention without failing the sync when the payload store is unavailable and to include `payloads_retained` and `payload_retention_failures` in `IntervalsSyncResult`.
- Add Notion workout extension schema helpers in `src/notion/infrastructure/workout_schema.py` and a migration helper script `scripts/ensure_notion_workout_schema.py` to idempotently add extension properties to the Notion database.
- Extend the Notion client interface and concrete `NotionClient` with `retrieve_database` and `update_database`, and update `NotionWorkoutAdapter` to fetch/inspect the workout database schema, only write compatible extension properties, and preserve legacy calendar `Date` semantics when `Start Time` is absent.
- Improve quality issue merging by including `message`, `details`, and normalized detail canonicalization so semantically different issues are not merged incorrectly.
- Update README and `openapi.json` to document retention behavior, the migration command, and timezone validation behavior.

### Testing

- Ran unit and integration tests with `pytest` (repository test suite) including new tests for timezone validation, payload retention behaviors, Notion extension schema flows, workout date handling, and quality-issue merging, and all tests passed.
- Ensured OpenAPI contract generation and route changes by regenerating `openapi.json` with `uv run python generate_openapi.py` and validated route responses through the added API tests that assert HTTP 422 on invalid timezones.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a58b88613988330b3429e3114378fb7)